### PR TITLE
Feat: HomeModalView UI 구현

### DIFF
--- a/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
+++ b/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0E36BA9A2B25D192003EA141 /* Extention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BA992B25D192003EA141 /* Extention.swift */; };
 		0E36BAA32B26B696003EA141 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BAA22B26B696003EA141 /* HomeViewModel.swift */; };
 		0E36BAA62B26B6BF003EA141 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BAA52B26B6BF003EA141 /* Color.swift */; };
+		9E9A102B2B26CF6600A2A73E /* HomeModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9A102A2B26CF6600A2A73E /* HomeModalView.swift */; };
 		CEB9F57E2B219941005A338E /* PJ2T12_Again12App.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9F57D2B219941005A338E /* PJ2T12_Again12App.swift */; };
 		CEB9F5822B219944005A338E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEB9F5812B219944005A338E /* Assets.xcassets */; };
 		CEB9F5852B219944005A338E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEB9F5842B219944005A338E /* Preview Assets.xcassets */; };
@@ -29,6 +30,7 @@
 		0E36BA992B25D192003EA141 /* Extention.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extention.swift; sourceTree = "<group>"; };
 		0E36BAA22B26B696003EA141 /* HomeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		0E36BAA52B26B6BF003EA141 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		9E9A102A2B26CF6600A2A73E /* HomeModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModalView.swift; sourceTree = "<group>"; };
 		CEB9F57A2B219941005A338E /* PJ2T12_Again12.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PJ2T12_Again12.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEB9F57D2B219941005A338E /* PJ2T12_Again12App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PJ2T12_Again12App.swift; sourceTree = "<group>"; };
 		CEB9F5812B219944005A338E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 				0E36BA7D2B22F41E003EA141 /* EditView.swift */,
 				CEB9F5982B21A9A9005A338E /* HistoryView.swift */,
 				CEB9F5922B21A937005A338E /* HomeView.swift */,
+				9E9A102A2B26CF6600A2A73E /* HomeModalView.swift */,
 				CEB9F59C2B21A9CE005A338E /* SettingsView.swift */,
 				CEB9F59A2B21A9C5005A338E /* SocialView.swift */,
 				CEB9F5962B21A966005A338E /* StatusView.swift */,
@@ -215,6 +218,7 @@
 				CEB9F5932B21A937005A338E /* HomeView.swift in Sources */,
 				0E36BA9A2B25D192003EA141 /* Extention.swift in Sources */,
 				CEB9F5912B21A925005A338E /* TodoriTapView.swift in Sources */,
+				9E9A102B2B26CF6600A2A73E /* HomeModalView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/HomeViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/HomeViewModel.swift
@@ -12,4 +12,6 @@ class HomeViewModel: ObservableObject {
     @Published var showingAlert = false
     @Published var showingModalAlert = false
     @Published var todo = ""
+    @Published var images: [String] = ["paperplane", "book.closed", "moon", "dumbbell"]
+    @Published var selectedImage = ""
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/HomeViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/HomeViewModel.swift
@@ -11,4 +11,5 @@ import Foundation
 class HomeViewModel: ObservableObject {
     @Published var showingAlert = false
     @Published var showingModalAlert = false
+    @Published var todo = ""
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
@@ -8,11 +8,27 @@
 import SwiftUI
 
 struct HomeModalView: View {
-    @Binding var todo: String
+    @State private var todoTemp: String = ""
+    @State private var todo: String = ""
     
     var body: some View {
-        TextField(todo, text: $todo)
-        Button("OK", action: {})
+        VStack {
+            HStack {
+                
+            }
+            TextField("", text: $todoTemp)
+            HStack {
+                Button("취소", action: {
+                    todoTemp = ""
+//                    print("todo: \(todo), todoTemp:\(todoTemp)")
+                })
+                Button("저장", action: {
+                    todo = todoTemp
+                    todoTemp = ""
+//                    print("todo: \(todo), todoTemp:\(todoTemp)")
+                })
+            }
+        }
     }
 }
 

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
@@ -9,59 +9,64 @@ import SwiftUI
 
 struct HomeModalView: View {
     @StateObject private var homeVM = HomeViewModel()
+    @Binding var shown: Bool
     @State private var todoTemp: String = ""
-    private var circleSize: CGFloat = 60
-    private var imageSize: CGFloat = 30
+    var circleSize: CGFloat = 60
+    var imageSize: CGFloat = 30
     
     var body: some View {
         VStack {
-            HStack {
-                ForEach(homeVM.images, id: \.self) { image in
-                    ZStack {
-                        Circle()
-                            .frame(width: circleSize, height: circleSize)
-                            .foregroundStyle(.blue)
-                        Image(systemName: image)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: imageSize, height: imageSize)
+            VStack {
+                HStack {
+                    ForEach(homeVM.images, id: \.self) { image in
+                        ZStack {
+                            Circle()
+                                .frame(width: circleSize, height: circleSize)
+                                .foregroundStyle(.blue)
+                            Image(systemName: image)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: imageSize, height: imageSize)
+                        }
                     }
                 }
-            }
-            .padding(.top, 25)
-            
-            TextField("", text: $todoTemp)
-                .background(.white)
-                .textFieldStyle(.roundedBorder)
-                .padding()
-            
-            Spacer()
-            Divider()
-            
-            HStack {
-                Button("취소", action: {
-                    todoTemp = ""
-                    homeVM.showingModalAlert = false
-                })
-                .frame(width: UIScreen.main.bounds.width / 2 - 40)
+                .padding(.top, 25)
                 
+                TextField("", text: $todoTemp)
+                    .background(.white)
+                    .textFieldStyle(.roundedBorder)
+                    .padding()
+                
+                Spacer()
                 Divider()
-                    .frame(height: 40)
                 
-                Button("저장", action: {
-                    homeVM.todo = todoTemp
-                    todoTemp = ""
-                    homeVM.showingModalAlert = false
-                })
-                .frame(width: UIScreen.main.bounds.width / 2 - 40)
+                HStack {
+                    Button("취소", action: {
+                        todoTemp = ""
+                        shown = false
+                    })
+                    .frame(width: UIScreen.main.bounds.width / 2 - 40)
+                    
+                    Divider()
+                        .frame(height: 40)
+                    
+                    Button("저장", action: {
+                        homeVM.todo = todoTemp
+                        todoTemp = ""
+                        shown = false
+                    })
+                    .frame(width: UIScreen.main.bounds.width / 2 - 40)
+                }
             }
+            .frame(width: UIScreen.main.bounds.width - 50, height: 220)
+            .background(.gray)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
         }
-        .frame(width: UIScreen.main.bounds.width - 50, height: 220)
-        .background(.gray)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
+        .background(.ultraThinMaterial)
     }
 }
 
-#Preview {
-    HomeModalView()
-}
+//#Preview {
+//    HomeModalView()
+//}

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
@@ -19,14 +19,21 @@ struct HomeModalView: View {
             VStack {
                 HStack {
                     ForEach(homeVM.images, id: \.self) { image in
-                        ZStack {
-                            Circle()
-                                .frame(width: circleSize, height: circleSize)
-                                .foregroundStyle(.blue)
-                            Image(systemName: image)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: imageSize, height: imageSize)
+                        Button {
+                            homeVM.selectedImage = image
+                            print(homeVM.selectedImage)
+                            } label: {
+                                ZStack {
+                                Circle()
+                                    .frame(width: circleSize, height: circleSize)
+                                    .foregroundStyle(.white)
+                                Image(systemName: image)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .foregroundStyle(.black)
+                                    .frame(width: imageSize, height: imageSize)
+                            }
+                                .padding(.horizontal, 8)
                         }
                     }
                 }
@@ -41,21 +48,25 @@ struct HomeModalView: View {
                 Divider()
                 
                 HStack {
-                    Button("취소", action: {
+                    Button {
                         todoTemp = ""
                         shown = false
-                    })
-                    .frame(width: UIScreen.main.bounds.width / 2 - 40)
+                    } label: {
+                        Text("취소")
+                            .frame(width: UIScreen.main.bounds.width / 2 - 40)
+                    }
                     
                     Divider()
                         .frame(height: 40)
                     
-                    Button("저장", action: {
+                    Button {
                         homeVM.todo = todoTemp
                         todoTemp = ""
                         shown = false
-                    })
-                    .frame(width: UIScreen.main.bounds.width / 2 - 40)
+                    } label: {
+                        Text("저장")
+                            .frame(width: UIScreen.main.bounds.width / 2 - 40)
+                    }
                 }
             }
             .frame(width: UIScreen.main.bounds.width - 50, height: 220)

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
@@ -22,18 +22,18 @@ struct HomeModalView: View {
                         Button {
                             homeVM.selectedImage = image
                             print(homeVM.selectedImage)
-                            } label: {
-                                ZStack {
+                        } label: {
+                            ZStack {
                                 Circle()
                                     .frame(width: circleSize, height: circleSize)
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(homeVM.selectedImage == image ? .yellow : .white)
                                 Image(systemName: image)
                                     .resizable()
                                     .aspectRatio(contentMode: .fit)
                                     .foregroundStyle(.black)
                                     .frame(width: imageSize, height: imageSize)
                             }
-                                .padding(.horizontal, 8)
+                            .padding(.horizontal, 8)
                         }
                     }
                 }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
@@ -10,28 +10,56 @@ import SwiftUI
 struct HomeModalView: View {
     @StateObject private var homeVM = HomeViewModel()
     @State private var todoTemp: String = ""
+    private var circleSize: CGFloat = 60
+    private var imageSize: CGFloat = 30
     
     var body: some View {
         VStack {
             HStack {
-                
+                ForEach(homeVM.images, id: \.self) { image in
+                    ZStack {
+                        Circle()
+                            .frame(width: circleSize, height: circleSize)
+                            .foregroundStyle(.blue)
+                        Image(systemName: image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: imageSize, height: imageSize)
+                    }
+                }
             }
+            .padding(.top, 25)
+            
             TextField("", text: $todoTemp)
+                .background(.white)
+                .textFieldStyle(.roundedBorder)
+                .padding()
+            
+            Spacer()
+            Divider()
+            
             HStack {
                 Button("취소", action: {
                     todoTemp = ""
-//                    print("todo: \(todo), todoTemp:\(todoTemp)")
                 })
+                .frame(width: UIScreen.main.bounds.width / 2 - 40)
+                
+                Divider()
+                    .frame(height: 40)
+                
                 Button("저장", action: {
                     homeVM.todo = todoTemp
                     todoTemp = ""
-//                    print("todo: \(todo), todoTemp:\(todoTemp)")
                 })
+                .frame(width: UIScreen.main.bounds.width / 2 - 40)
             }
         }
+        .frame(width: UIScreen.main.bounds.width - 50, height: 220)
+        .background(.gray)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 }
 
-//#Preview {
-//    HomeModalView()
-//}
+#Preview {
+    HomeModalView()
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
@@ -41,6 +41,7 @@ struct HomeModalView: View {
             HStack {
                 Button("취소", action: {
                     todoTemp = ""
+                    homeVM.showingModalAlert = false
                 })
                 .frame(width: UIScreen.main.bounds.width / 2 - 40)
                 
@@ -50,6 +51,7 @@ struct HomeModalView: View {
                 Button("저장", action: {
                     homeVM.todo = todoTemp
                     todoTemp = ""
+                    homeVM.showingModalAlert = false
                 })
                 .frame(width: UIScreen.main.bounds.width / 2 - 40)
             }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
@@ -1,0 +1,21 @@
+//
+//  HomeModalView.swift
+//  PJ2T12_Again12
+//
+//  Created by Eunsu JEONG on 12/11/23.
+//
+
+import SwiftUI
+
+struct HomeModalView: View {
+    @Binding var todo: String
+    
+    var body: some View {
+        TextField(todo, text: $todo)
+        Button("OK", action: {})
+    }
+}
+
+//#Preview {
+//    HomeModalView()
+//}

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct HomeModalView: View {
+    @StateObject private var homeVM = HomeViewModel()
     @State private var todoTemp: String = ""
-    @State private var todo: String = ""
     
     var body: some View {
         VStack {
@@ -23,7 +23,7 @@ struct HomeModalView: View {
 //                    print("todo: \(todo), todoTemp:\(todoTemp)")
                 })
                 Button("저장", action: {
-                    todo = todoTemp
+                    homeVM.todo = todoTemp
                     todoTemp = ""
 //                    print("todo: \(todo), todoTemp:\(todoTemp)")
                 })

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeModalView.swift
@@ -11,6 +11,7 @@ struct HomeModalView: View {
     @StateObject private var homeVM = HomeViewModel()
     @Binding var shown: Bool
     @State private var todoTemp: String = ""
+    @State private var selectedImageTemp = ""
     var circleSize: CGFloat = 60
     var imageSize: CGFloat = 30
     
@@ -20,13 +21,12 @@ struct HomeModalView: View {
                 HStack {
                     ForEach(homeVM.images, id: \.self) { image in
                         Button {
-                            homeVM.selectedImage = image
-                            print(homeVM.selectedImage)
+                            selectedImageTemp = image
                         } label: {
                             ZStack {
                                 Circle()
                                     .frame(width: circleSize, height: circleSize)
-                                    .foregroundStyle(homeVM.selectedImage == image ? .yellow : .white)
+                                    .foregroundStyle(selectedImageTemp == image ? .yellow : .white)
                                 Image(systemName: image)
                                     .resizable()
                                     .aspectRatio(contentMode: .fit)
@@ -50,6 +50,7 @@ struct HomeModalView: View {
                 HStack {
                     Button {
                         todoTemp = ""
+                        selectedImageTemp = ""
                         shown = false
                     } label: {
                         Text("취소")
@@ -61,7 +62,9 @@ struct HomeModalView: View {
                     
                     Button {
                         homeVM.todo = todoTemp
+                        homeVM.selectedImage = selectedImageTemp
                         todoTemp = ""
+                        selectedImageTemp = ""
                         shown = false
                     } label: {
                         Text("저장")

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
@@ -13,107 +13,105 @@ struct HomeView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                ZStack {
-                    Color(hex: 0xFFFAE1)
-                        .ignoresSafeArea()
-                    ScrollView {
-                        // NavBar
-                        HStack {
-                            Text("2023. 12")
+                Color(hex: 0xFFFAE1)
+                    .ignoresSafeArea()
+                ScrollView {
+                    // NavBar
+                    HStack {
+                        Text("2023. 12")
+                            .foregroundStyle(Color(hex: 0x432D00))
+                            .font(.largeTitle)
+                            .fontWeight(.medium)
+                        Spacer()
+                        NavigationLink {
+                            HistoryView()
+                        } label: {
+                            Image(systemName: "doc.text")
+                                .font(.title)
                                 .foregroundStyle(Color(hex: 0x432D00))
-                                .font(.largeTitle)
-                                .fontWeight(.medium)
-                            Spacer()
-                            NavigationLink {
-                                HistoryView()
-                            } label: {
-                                Image(systemName: "doc.text")
-                                    .font(.title)
-                                    .foregroundStyle(Color(hex: 0x432D00))
-                            }
-                        }
-                        .padding(.bottom, 4)
-                        VStack(spacing: 16) {
-                            // 하고 싶은 일
-                            VStack {
-                                HStack {
-                                    Text("하고 싶으면")
-                                        .bold()
-                                    Spacer()
-                                }
-                                VStack {
-                                    ForEach(toDoList) { todo in
-                                        Button() {
-                                            homeVM.showingAlert = true
-                                        } label: {
-                                            Text("🍞 " + todo.title)
-                                                .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
-                                        }
-                                    }
-                                    if toDoList.count < 3 {
-                                        Button {
-                                            homeVM.showingModalAlert = true
-                                        } label: {
-                                            Text("새로운 투두를 추가해보세요")
-                                                .padding()
-                                                .foregroundStyle(.black)
-                                                .frame(maxWidth: .infinity, alignment: .center)
-                                                .background(
-                                                    RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                                        .fill(Color.white.opacity(0.6))
-                                                )
-                                                .padding(.top, 32)
-                                        }
-                                    }
-                                }
-                                .padding()
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 10)
-                                        .stroke(Color(hex: 0xA58B00).opacity(0.32), lineWidth: 2)
-                                )
-                            }
-                            // 해야 하는 일
-                            VStack {
-                                HStack {
-                                    Text("해야 하면")
-                                        .bold()
-                                    Spacer()
-                                }
-                                VStack {
-                                    ForEach(haveToList) { todo in
-                                        Button() {
-                                            homeVM.showingAlert = true
-                                        } label: {
-                                            Text("🍁 " + todo.title)
-                                                .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB76300))
-                                        }
-                                    }
-                                    if haveToList.count < 3 {
-                                        Button {
-                                            homeVM.showingModalAlert = true
-                                        } label: {
-                                            Text("새로운 투두를 추가해보세요")
-                                                .padding()
-                                                .foregroundStyle(.black)
-                                                .frame(maxWidth: .infinity, alignment: .center)
-                                                .background(
-                                                    RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                                        .fill(Color.white.opacity(0.6))
-                                                )
-                                                .padding(.top, 32)
-                                        }
-                                    }
-                                }
-                                .padding()
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 10)
-                                        .stroke(Color(hex: 0xA58B00).opacity(0.32), lineWidth: 2)
-                                )
-                            }
                         }
                     }
-                    .padding()
+                    .padding(.bottom, 4)
+                    VStack(spacing: 16) {
+                        // 하고 싶은 일
+                        VStack {
+                            HStack {
+                                Text("하고 싶으면")
+                                    .bold()
+                                Spacer()
+                            }
+                            VStack {
+                                ForEach(toDoList) { todo in
+                                    Button() {
+                                        homeVM.showingAlert = true
+                                    } label: {
+                                        Text("🍞 " + todo.title)
+                                            .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
+                                    }
+                                }
+                                if toDoList.count < 3 {
+                                    Button {
+                                        homeVM.showingModalAlert = true
+                                    } label: {
+                                        Text("새로운 투두를 추가해보세요")
+                                            .padding()
+                                            .foregroundStyle(.black)
+                                            .frame(maxWidth: .infinity, alignment: .center)
+                                            .background(
+                                                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                                                    .fill(Color.white.opacity(0.6))
+                                            )
+                                            .padding(.top, 32)
+                                    }
+                                }
+                            }
+                            .padding()
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(Color(hex: 0xA58B00).opacity(0.32), lineWidth: 2)
+                            )
+                        }
+                        // 해야 하는 일
+                        VStack {
+                            HStack {
+                                Text("해야 하면")
+                                    .bold()
+                                Spacer()
+                            }
+                            VStack {
+                                ForEach(haveToList) { todo in
+                                    Button() {
+                                        homeVM.showingAlert = true
+                                    } label: {
+                                        Text("🍁 " + todo.title)
+                                            .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB76300))
+                                    }
+                                }
+                                if haveToList.count < 3 {
+                                    Button {
+                                        homeVM.showingModalAlert = true
+                                    } label: {
+                                        Text("새로운 투두를 추가해보세요")
+                                            .padding()
+                                            .foregroundStyle(.black)
+                                            .frame(maxWidth: .infinity, alignment: .center)
+                                            .background(
+                                                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                                                    .fill(Color.white.opacity(0.6))
+                                            )
+                                            .padding(.top, 32)
+                                    }
+                                }
+                            }
+                            .padding()
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(Color(hex: 0xA58B00).opacity(0.32), lineWidth: 2)
+                            )
+                        }
+                    }
                 }
+                .padding()
                 
                 if homeVM.showingModalAlert {
                     HomeModalView(shown: $homeVM.showingModalAlert)

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
@@ -63,8 +63,8 @@ struct HomeView: View {
                                             )
                                             .padding(.top, 32)
                                     }
-                                    .alert("", isPresented: $homeVM.showingModalAlert) {
-                                        HomeModalView(todo: $homeVM.todo)
+                                    .alert("새로운 투두를 추가해보세요", isPresented: $homeVM.showingModalAlert) {
+                                        HomeModalView()
                                     }
                                 }
                             }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
@@ -104,6 +104,9 @@ struct HomeView: View {
                                             )
                                             .padding(.top, 32)
                                     }
+                                    .alert("새로운 투두를 추가해보세요", isPresented: $homeVM.showingModalAlert) {
+                                        HomeModalView()
+                                    }
                                 }
                             }
                             .padding()

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
@@ -102,9 +102,6 @@ struct HomeView: View {
                                                 )
                                                 .padding(.top, 32)
                                         }
-                                        .alert("새로운 투두를 추가해보세요", isPresented: $homeVM.showingModalAlert) {
-                                            HomeModalView()
-                                        }
                                     }
                                 }
                                 .padding()
@@ -117,10 +114,9 @@ struct HomeView: View {
                     }
                     .padding()
                 }
-                .blur(radius: homeVM.showingModalAlert ? 30 : 0)
                 
                 if homeVM.showingModalAlert {
-                    HomeModalView()
+                    HomeModalView(shown: $homeVM.showingModalAlert)
                 }
             }
             .alert("일정을 달성 하셨나요?" ,isPresented: $homeVM.showingAlert) {

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
@@ -13,111 +13,115 @@ struct HomeView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color(hex: 0xFFFAE1)
-                    .ignoresSafeArea()
-                ScrollView {
-                    // NavBar
-                    HStack {
-                        Text("2023. 12")
-                            .foregroundStyle(Color(hex: 0x432D00))
-                            .font(.largeTitle)
-                            .fontWeight(.medium)
-                        Spacer()
-                        NavigationLink {
-                            HistoryView()
-                        } label: {
-                            Image(systemName: "doc.text")
-                                .font(.title)
+                ZStack {
+                    Color(hex: 0xFFFAE1)
+                        .ignoresSafeArea()
+                    ScrollView {
+                        // NavBar
+                        HStack {
+                            Text("2023. 12")
                                 .foregroundStyle(Color(hex: 0x432D00))
+                                .font(.largeTitle)
+                                .fontWeight(.medium)
+                            Spacer()
+                            NavigationLink {
+                                HistoryView()
+                            } label: {
+                                Image(systemName: "doc.text")
+                                    .font(.title)
+                                    .foregroundStyle(Color(hex: 0x432D00))
+                            }
+                        }
+                        .padding(.bottom, 4)
+                        VStack(spacing: 16) {
+                            // 하고 싶은 일
+                            VStack {
+                                HStack {
+                                    Text("하고 싶으면")
+                                        .bold()
+                                    Spacer()
+                                }
+                                VStack {
+                                    ForEach(toDoList) { todo in
+                                        Button() {
+                                            homeVM.showingAlert = true
+                                        } label: {
+                                            Text("🍞 " + todo.title)
+                                                .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
+                                        }
+                                    }
+                                    if toDoList.count < 3 {
+                                        Button {
+                                            homeVM.showingModalAlert = true
+                                        } label: {
+                                            Text("새로운 투두를 추가해보세요")
+                                                .padding()
+                                                .foregroundStyle(.black)
+                                                .frame(maxWidth: .infinity, alignment: .center)
+                                                .background(
+                                                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                                                        .fill(Color.white.opacity(0.6))
+                                                )
+                                                .padding(.top, 32)
+                                        }
+                                    }
+                                }
+                                .padding()
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .stroke(Color(hex: 0xA58B00).opacity(0.32), lineWidth: 2)
+                                )
+                            }
+                            // 해야 하는 일
+                            VStack {
+                                HStack {
+                                    Text("해야 하면")
+                                        .bold()
+                                    Spacer()
+                                }
+                                VStack {
+                                    ForEach(haveToList) { todo in
+                                        Button() {
+                                            homeVM.showingAlert = true
+                                        } label: {
+                                            Text("🍁 " + todo.title)
+                                                .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB76300))
+                                        }
+                                    }
+                                    if haveToList.count < 3 {
+                                        Button {
+                                            homeVM.showingModalAlert = true
+                                        } label: {
+                                            Text("새로운 투두를 추가해보세요")
+                                                .padding()
+                                                .foregroundStyle(.black)
+                                                .frame(maxWidth: .infinity, alignment: .center)
+                                                .background(
+                                                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                                                        .fill(Color.white.opacity(0.6))
+                                                )
+                                                .padding(.top, 32)
+                                        }
+                                        .alert("새로운 투두를 추가해보세요", isPresented: $homeVM.showingModalAlert) {
+                                            HomeModalView()
+                                        }
+                                    }
+                                }
+                                .padding()
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .stroke(Color(hex: 0xA58B00).opacity(0.32), lineWidth: 2)
+                                )
+                            }
                         }
                     }
-                    .padding(.bottom, 4)
-                    VStack(spacing: 16) {
-                        // 하고 싶은 일
-                        VStack {
-                            HStack {
-                                Text("하고 싶으면")
-                                    .bold()
-                                Spacer()
-                            }
-                            VStack {
-                                ForEach(toDoList) { todo in
-                                    Button() {
-                                        homeVM.showingAlert = true
-                                    } label: {
-                                        Text("🍞 " + todo.title)
-                                            .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
-                                    }
-                                }
-                                if toDoList.count < 3 {
-                                    Button {
-                                        homeVM.showingModalAlert = true
-                                    } label: {
-                                        Text("새로운 투두를 추가해보세요")
-                                            .padding()
-                                            .foregroundStyle(.black)
-                                            .frame(maxWidth: .infinity, alignment: .center)
-                                            .background(
-                                                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                                    .fill(Color.white.opacity(0.6))
-                                            )
-                                            .padding(.top, 32)
-                                    }
-                                    .alert("새로운 투두를 추가해보세요", isPresented: $homeVM.showingModalAlert) {
-                                        HomeModalView()
-                                    }
-                                }
-                            }
-                            .padding()
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(Color(hex: 0xA58B00).opacity(0.32), lineWidth: 2)
-                            )
-                        }
-                        // 해야 하는 일
-                        VStack {
-                            HStack {
-                                Text("해야 하면")
-                                    .bold()
-                                Spacer()
-                            }
-                            VStack {
-                                ForEach(haveToList) { todo in
-                                    Button() {
-                                        homeVM.showingAlert = true
-                                    } label: {
-                                        Text("🍁 " + todo.title)
-                                            .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB76300))
-                                    }
-                                }
-                                if haveToList.count < 3 {
-                                    Button {
-                                        homeVM.showingModalAlert = true
-                                    } label: {
-                                        Text("새로운 투두를 추가해보세요")
-                                            .padding()
-                                            .foregroundStyle(.black)
-                                            .frame(maxWidth: .infinity, alignment: .center)
-                                            .background(
-                                                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                                    .fill(Color.white.opacity(0.6))
-                                            )
-                                            .padding(.top, 32)
-                                    }
-                                    .alert("새로운 투두를 추가해보세요", isPresented: $homeVM.showingModalAlert) {
-                                        HomeModalView()
-                                    }
-                                }
-                            }
-                            .padding()
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(Color(hex: 0xA58B00).opacity(0.32), lineWidth: 2)
-                            )
-                        }
-                    }
+                    .padding()
                 }
-                .padding()
+                .blur(radius: homeVM.showingModalAlert ? 30 : 0)
+                
+                if homeVM.showingModalAlert {
+                    HomeModalView()
+                }
             }
             .alert("일정을 달성 하셨나요?" ,isPresented: $homeVM.showingAlert) {
                 NavigationLink("일정 수정") { DetailView() }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/HomeView.swift
@@ -63,6 +63,9 @@ struct HomeView: View {
                                             )
                                             .padding(.top, 32)
                                     }
+                                    .alert("", isPresented: $homeVM.showingModalAlert) {
+                                        HomeModalView(todo: $homeVM.todo)
+                                    }
                                 }
                             }
                             .padding()


### PR DESCRIPTION
## 이슈번호
🔐 close #22 #31 #32 #33 

## 작업사항
- HomeModalView가 전체 HomeView를 덮으며 나타납니다.
- HomeModalView에서 선택한 이미지와 작성한 투두는 HomeViewModel에서 관리됩니다.
- HomeModalView에서 작성한 투두와 선택한 이미지는 취소를 누르면 사라지고 저장해야만 HomeViewModel에서 관리할 수 있습니다.

## 향후 작업 예정
- 색이나 디테일한 간격은 추후 뷰 디자인이 완료되면 할 예정입니다.
- 저장을 누르면 실제 CoreData에 내용이 저장되도록 할 예정입니다.

## 스크린샷

- UI 작업이었다면 개발 전과 후 화면을 캡처해서 올려주세요.

| 작업 전 | 작업 후 |
| ----- | ----- | 
|  |<img width="250" alt="스크린샷 2023-12-11 오후 4 50 35" src="https://github.com/APP-iOS3rd/PJ2T12_Again12/assets/106911494/e5c44685-05ed-41cc-abf9-f42b0a1b6841">| 