### PR TITLE
Feat: 휴지통, 뷰전환

### DIFF
--- a/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
+++ b/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0E36BA9A2B25D192003EA141 /* Extention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BA992B25D192003EA141 /* Extention.swift */; };
 		0E36BAA32B26B696003EA141 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BAA22B26B696003EA141 /* HomeViewModel.swift */; };
 		0E36BAA62B26B6BF003EA141 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BAA52B26B6BF003EA141 /* Color.swift */; };
+		0E36BAB22B26F64C003EA141 /* EditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BAB12B26F64C003EA141 /* EditViewModel.swift */; };
 		CEB9F57E2B219941005A338E /* PJ2T12_Again12App.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9F57D2B219941005A338E /* PJ2T12_Again12App.swift */; };
 		CEB9F5822B219944005A338E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEB9F5812B219944005A338E /* Assets.xcassets */; };
 		CEB9F5852B219944005A338E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEB9F5842B219944005A338E /* Preview Assets.xcassets */; };
@@ -29,6 +30,7 @@
 		0E36BA992B25D192003EA141 /* Extention.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extention.swift; sourceTree = "<group>"; };
 		0E36BAA22B26B696003EA141 /* HomeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		0E36BAA52B26B6BF003EA141 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		0E36BAB12B26F64C003EA141 /* EditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewModel.swift; sourceTree = "<group>"; };
 		CEB9F57A2B219941005A338E /* PJ2T12_Again12.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PJ2T12_Again12.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEB9F57D2B219941005A338E /* PJ2T12_Again12App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PJ2T12_Again12App.swift; sourceTree = "<group>"; };
 		CEB9F5812B219944005A338E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -83,11 +85,11 @@
 			isa = PBXGroup;
 			children = (
 				CEB9F57D2B219941005A338E /* PJ2T12_Again12App.swift */,
-				CEB9F58C2B219A48005A338E /* Views */,
-				CEB9F58D2B219A66005A338E /* ViewModels */,
+				0E36BAA42B26B6BF003EA141 /* Extensions */,
 				CEB9F58B2B219A1C005A338E /* Models */,
 				CEB9F5812B219944005A338E /* Assets.xcassets */,
-				0E36BAA42B26B6BF003EA141 /* Extensions */,
+				CEB9F58C2B219A48005A338E /* Views */,
+				CEB9F58D2B219A66005A338E /* ViewModels */,
 				CEB9F5832B219944005A338E /* Preview Content */,
 			);
 			path = PJ2T12_Again12;
@@ -128,6 +130,7 @@
 			isa = PBXGroup;
 			children = (
 				0E36BAA22B26B696003EA141 /* HomeViewModel.swift */,
+				0E36BAB12B26F64C003EA141 /* EditViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -202,6 +205,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0E36BAB22B26F64C003EA141 /* EditViewModel.swift in Sources */,
 				CEB9F5992B21A9A9005A338E /* HistoryView.swift in Sources */,
 				CEB9F5952B21A950005A338E /* DetailView.swift in Sources */,
 				CEB9F57E2B219941005A338E /* PJ2T12_Again12App.swift in Sources */,
@@ -351,6 +355,8 @@
 				DEVELOPMENT_TEAM = BQUJTNYMGY;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "앱에서 사진앱에 접근 하려고 합니다. ";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -380,6 +386,8 @@
 				DEVELOPMENT_TEAM = BQUJTNYMGY;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "앱에서 사진앱에 접근 하려고 합니다. ";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/PJ2T12_Again12/PJ2T12_Again12/PJ2T12_Again12App.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/PJ2T12_Again12App.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct PJ2T12_Again12App: App {
     var body: some Scene {
         WindowGroup {
-            HomeView()
+            TodoriTapView()
         }
     }
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/PJ2T12_Again12App.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/PJ2T12_Again12App.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct PJ2T12_Again12App: App {
     var body: some Scene {
         WindowGroup {
-            EditView()
+            HomeView()
         }
     }
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/PJ2T12_Again12App.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/PJ2T12_Again12App.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct PJ2T12_Again12App: App {
     var body: some Scene {
         WindowGroup {
-            TodoriTapView()
+            EditView()
         }
     }
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/EditViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/EditViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  EditViewModel.swift
+//  PJ2T12_Again12
+//
+//  Created by kwon ji won on 12/11/23.
+//
+
+import Foundation
+import Photos
+
+class EditViewModel: ObservableObject {
+    @Published var albumPermissionGranted = false
+    
+    func checkAlbumPermission() {
+        PHPhotoLibrary.requestAuthorization { [weak self] status in
+            switch status {
+            case .authorized:
+                //Publishing changes from background threads is not allowed; make sure to publish values from the main thread (via operators like receive(on:)) on model updates.
+                //UI관련 변수를 업데이트할 때에는 main 쓰레드에서 업데이트 될 수 있도록, await MainActor.run {}블록으로 감싸줘야한다.
+                //-> DispatchQueue.main 을 대체하는 방식
+                DispatchQueue.main.async {
+                    self?.albumPermissionGranted = true
+                }
+                print("Album: 권한 허용")
+            case .denied:
+                print("Album: 권한 거부")
+            case .restricted, .notDetermined:
+                print("Album: 선택하지 않음")
+            default:
+                break
+            }
+        }
+    }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/EditView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/EditView.swift
@@ -15,81 +15,124 @@ struct EditView: View {
     @State private var image = UIImage()
     @State private var userText: String = ""
     @State private var checkSave = false
+    @State private var showAlert = false
+    @State private var goToHome = false
     
     var body: some View {
-        NavigationView {
-            ScrollView {
-                VStack {
-                    HStack(spacing: 20) {
-                        Image(systemName: "airplane")
-                            .font(.title2)
-                        Text("아침 일찍 일어나기")
-                            .font(.system(size: 25))
-                            .bold()
-                    }
-                    .frame(width: 340, height: 60)
-                    HStack {
-                        Button(action: {
-                            viewModel.checkAlbumPermission()
-                            if viewModel.albumPermissionGranted {
-                                self.openPhoto = true  
+        NavigationStack {
+            ZStack {
+                Color(hex: 0xFFFAE1)
+                    .ignoresSafeArea()
+                ScrollView {
+                    VStack() {
+                        HStack(alignment: .center, spacing: 20) {
+                            Spacer()
+                            Spacer()
+                            Image(systemName: "airplane")
+                                .font(.title2)
+                            Text("아침 일찍 일어나기")
+                                .font(.system(size: 25))
+                                .bold()
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.5)
+                                .foregroundColor(Color(hex: 0xB76300))
+                            Spacer()
+                            Button(action: {
+                                showAlert.toggle()
+                            }) {
+                                Image(systemName: "trash")
+                                    .font(.title2)
+                                    .opacity(checkSave ? 1.0 : 0 )
                             }
-                        }) {
-                            ZStack {
-                                RoundedRectangle(cornerRadius: 12)
-                                    .frame(width: 90, height: 90)
-                                    .foregroundColor(Color(red: 0xD9 / 255.0, green: 0xD9 / 255.0, blue: 0xD9 / 255.0))
-                                Image(systemName: "camera.circle")
-                                    .font(/*@START_MENU_TOKEN@*/.title/*@END_MENU_TOKEN@*/)
-                                    .foregroundColor(.white)
+                            .alert(isPresented: $showAlert) {
+                                Alert(title: Text("삭제하시겠습니까?"),
+                                      message: nil,
+                                      primaryButton: .cancel(),
+                                      secondaryButton: .destructive(Text("삭제")) {
+                                    //삭제하기 버튼이 눌렸을 때 할 동작추가
+                                    //홈뷰에 status를 없앨껀지, 그 항목 자체를 삭제할껀지
+                                    goToHome.toggle()
+                                }
+                                )
+                            }
+                            .background(NavigationLink("", destination: HomeView(), isActive: $goToHome))
+                            Spacer()
+                        }
+                        .padding(.bottom, 20)
+                        
+                        HStack {
+                            Button(action: {
+                                viewModel.checkAlbumPermission()
+                                if viewModel.albumPermissionGranted {
+                                    self.openPhoto = true
+                                }
+                            }) {
+                                ZStack {
+                                    if !checkSave {
+                                        RoundedRectangle(cornerRadius: 12)
+                                            .frame(width: 90, height: 90)
+                                            .foregroundColor(Color(red: 0xD9 / 255.0, green: 0xD9 / 255.0, blue: 0xD9 / 255.0))
+                                        Image(systemName: "camera.circle")
+                                            .font(/*@START_MENU_TOKEN@*/.title/*@END_MENU_TOKEN@*/)
+                                            .foregroundColor(.white)
+                                    }
+                                }
+                            }
+                            .sheet(isPresented: $openPhoto) {
+                                ImagePicker(sourceType: .photoLibrary, selectedImage: self.$image)
                             }
                             .padding()
+                            Spacer()
+                                
                         }
-                        .sheet(isPresented: $openPhoto) {
-                            ImagePicker(sourceType: .photoLibrary, selectedImage: self.$image)
+                        if image.size != CGSize.zero {
+                            Image(uiImage: image)
+                                .resizable()
+                                .frame(width: 310, height: 310)
+                                .scaledToFit()
+                                .padding(.top,10)
+                                .padding(.bottom, 20)
                         }
-                        Spacer()
+                        
+                        if !checkSave {
+                            TextEditor(text: $userText)
+                                .frame(width: 320, height: 250)
+                                .lineSpacing(8)
+                                .keyboardType(.default)
+                                .border(Color.gray)
+                                .onTapGesture {
+                                }
+                                .overlay(
+                                    Text("할 일을 마치며 느낀점을 적어주세요")
+                                        .foregroundColor(.gray)
+                                        .opacity(userText.isEmpty ? 1 : 0)
+                                )
+                        } else {
+                            Text(userText)
+                                .frame(width: 320, height: 250)
+                                .lineSpacing(8)
+                                .background(Color.white)
+
+                        }
+                        
+                        Button(action: {
+                            checkSave.toggle()
+                        }) {
+                            Text(checkSave ? "수정하기" : "작성완료")
+                                .font(.headline)
+                                .foregroundColor(.white)
+                                .padding()
+                                .frame(width: 170, height: 50)
+                                .background(Color.blue)
+                                .cornerRadius(10)
+                        }
+                        .padding(.top, 60)
                     }
                     .padding()
-                    
-                    if image.size != CGSize.zero {
-                        Image(uiImage: image)
-                            .resizable()
-                            .frame(width: 320, height: 320)
-                            .scaledToFit()
-                    }
-                    
-                    TextEditor(text: $userText)
-                        .frame(width: 320, height: 250)
-                        .lineSpacing(8)
-                        .keyboardType(.default)
-                        .border(Color.gray)
-                        .onTapGesture {
-                        }
-                        .overlay(
-                            Text("할 일을 마치며 느낀점을 적어주세요")
-                                .foregroundColor(.gray)
-                                .padding(EdgeInsets(top: 8, leading: 4, bottom: 0, trailing: 4))
-                                .opacity(userText.isEmpty ? 1 : 0)
-                        )
-                    Spacer()
-                    
-                    Button(action: {
-                     checkSave = true
-                    }) {
-                        Text("달성 완료")
-                            .font(.headline)
-                            .foregroundColor(.white)
-                            .padding()
-                            .frame(width: 170, height: 50)
-                            .background(Color.blue)
-                            .cornerRadius(10)
-                    }
                 }
-                .padding()
+                .onTapGesture {
+                    hideKeyboard()
                 }
-            .onTapGesture {
-                hideKeyboard()
             }
         }
         

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/EditView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/EditView.swift
@@ -7,83 +7,92 @@
 
 import SwiftUI
 import Foundation
+import Photos
 
 struct EditView: View {
+    @StateObject private var viewModel = EditViewModel()
     @State private var openPhoto = false
     @State private var image = UIImage()
     @State private var userText: String = ""
+    @State private var checkSave = false
     
     var body: some View {
         NavigationView {
-                        ScrollView {
-            VStack {
-                HStack(spacing: 20) {
-                    Image(systemName: "airplane")
-                        .font(.title2)
-                    Text("아침 일찍 일어나기")
-                        .font(.system(size: 25))
-                        .bold()
-                }
-                .frame(width: 340, height: 60)
-                HStack() {
-                    Button(action: {
-                        self.openPhoto = true
-                    }) {
-                        ZStack() {
-                            RoundedRectangle(cornerRadius: 12)
-                                .frame(width: 90, height: 90)
-                                .foregroundColor(Color(red: 0xD9 / 255.0, green: 0xD9 / 255.0, blue: 0xD9 / 255.0))
-                            Image(systemName: "camera.circle")
-                                .font(/*@START_MENU_TOKEN@*/.title/*@END_MENU_TOKEN@*/)
-                                .foregroundColor(.white)
+            ScrollView {
+                VStack {
+                    HStack(spacing: 20) {
+                        Image(systemName: "airplane")
+                            .font(.title2)
+                        Text("아침 일찍 일어나기")
+                            .font(.system(size: 25))
+                            .bold()
+                    }
+                    .frame(width: 340, height: 60)
+                    HStack {
+                        Button(action: {
+                            viewModel.checkAlbumPermission()
+                            if viewModel.albumPermissionGranted {
+                                self.openPhoto = true  
+                            }
+                        }) {
+                            ZStack {
+                                RoundedRectangle(cornerRadius: 12)
+                                    .frame(width: 90, height: 90)
+                                    .foregroundColor(Color(red: 0xD9 / 255.0, green: 0xD9 / 255.0, blue: 0xD9 / 255.0))
+                                Image(systemName: "camera.circle")
+                                    .font(/*@START_MENU_TOKEN@*/.title/*@END_MENU_TOKEN@*/)
+                                    .foregroundColor(.white)
+                            }
+                            .padding()
                         }
-                        .padding()
+                        .sheet(isPresented: $openPhoto) {
+                            ImagePicker(sourceType: .photoLibrary, selectedImage: self.$image)
+                        }
+                        Spacer()
                     }
-                    .sheet(isPresented: $openPhoto) {
-                        ImagePicker(sourceType: .photoLibrary, selectedImage: self.$image)
+                    .padding()
+                    
+                    if image.size != CGSize.zero {
+                        Image(uiImage: image)
+                            .resizable()
+                            .frame(width: 320, height: 320)
+                            .scaledToFit()
                     }
+                    
+                    TextEditor(text: $userText)
+                        .frame(width: 320, height: 250)
+                        .lineSpacing(8)
+                        .keyboardType(.default)
+                        .border(Color.gray)
+                        .onTapGesture {
+                        }
+                        .overlay(
+                            Text("할 일을 마치며 느낀점을 적어주세요")
+                                .foregroundColor(.gray)
+                                .padding(EdgeInsets(top: 8, leading: 4, bottom: 0, trailing: 4))
+                                .opacity(userText.isEmpty ? 1 : 0)
+                        )
                     Spacer()
+                    
+                    Button(action: {
+                     checkSave = true
+                    }) {
+                        Text("달성 완료")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                            .padding()
+                            .frame(width: 170, height: 50)
+                            .background(Color.blue)
+                            .cornerRadius(10)
+                    }
                 }
                 .padding()
-                
-                if image.size != CGSize.zero {
-                    Image(uiImage: image)
-                        .resizable()
-                        .frame(width: 320, height: 320)
-                        .scaledToFit()
                 }
-                
-                TextEditor(text: $userText)
-                    .frame(width: 320, height: 250)
-                    .lineSpacing(8)
-                    .keyboardType(.default)
-                    .border(Color.gray)
-                    .onTapGesture {
-                    }
-                    .overlay(
-                        Text("할 일을 마치며 느낀점을 적어주세요")
-                            .foregroundColor(.gray)
-                            .padding(EdgeInsets(top: 8, leading: 4, bottom: 0, trailing: 4))
-                            .opacity(userText.isEmpty ? 1 : 0)
-                    )
-                Spacer()
-                Button(action: {
-                }) {
-                    Text("달성 완료")
-                        .font(.headline)
-                        .foregroundColor(.white)
-                        .padding()
-                        .frame(width: 170, height: 50)
-                        .background(Color.blue)
-                        .cornerRadius(10)
-                }
-            }
-            .padding()
             .onTapGesture {
                 hideKeyboard()
             }
         }
-    }
+        
     }
 }
 
@@ -111,6 +120,7 @@ struct ImagePicker: UIViewControllerRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
+    
     
     final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
         


### PR DESCRIPTION
## 이슈번호
🔐close #38  
🔓open #39 

## 작업사항
- 버튼을 누를 때 마다 작성완료 / 수정하기가 변경되고 뷰가 변경됩니다.
- 작성완료 버튼을 눌렀을 때 휴지통을 만들어 삭제하는 기능을 구현했스빈다.
- 휴지통을 눌러 삭제를 하면 HomeView로 이동합니다. 

## 향후 작업예정
- 휴지통을 눌러 삭제를 했을 때 데이터를 어떻게 삭제할지는 CoreData연결하면서 확인하면 될 것 같습니다.
- 휴지통을 눌러 삭제가 되면 NavigationStack으로 인해 뷰가 이동하는데 Back이 생기게 됩니다. 
  이런 방법을 사용하면 뷰가 계속 쌓이게 되서 추후 다른 방법으로 뷰를 이동 시킬 예정입니다. 
  fullScreenCover방법을 사용하면 된다는데, 다른 의견이 있으시다면 말씀해주세요~

## 의논사항
- 지금 가로 모드로 전환 했을 때, 사진불러오는 카메라 버튼이 padding으로 처리가 되지 않고 있어요.. 제가 뭘 놓치고 있는거 같은데 한번 같이 고민해 봐 주셨으면 좋겠습니다. 

## 스크린샷
- 사진을 불러오는 것 까지는 이전 PR에서 보여드려서 생략했습니다.

https://github.com/APP-iOS3rd/PJ2T12_Again12/assets/102846055/e8a3bbce-b857-4c25-abf9-e61b51d2db2f


