### PR TITLE
Add: Color Assets추가

### DIFF
--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/AlertBackWhite.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/AlertBackWhite.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF6",
+          "green" : "0xFE",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF6",
+          "green" : "0xFE",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/BackgroundYellow.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/BackgroundYellow.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE3",
+          "green" : "0xFA",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE3",
+          "green" : "0xFA",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/BorderBrown.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/BorderBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9A",
+          "green" : "0xD6",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9A",
+          "green" : "0xD6",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/CameraBackGray.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/CameraBackGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/CameraGray.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/CameraGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9F",
+          "green" : "0x9F",
+          "red" : "0x9F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9F",
+          "green" : "0x9F",
+          "red" : "0x9F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/DefaultBlack.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/DefaultBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x2D",
+          "red" : "0x43"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x2D",
+          "red" : "0x43"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/LoginButtonBrown.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/LoginButtonBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x87",
+          "green" : "0xBE",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x87",
+          "green" : "0xBE",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/NewTodoButtonBrown.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/NewTodoButtonBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF4",
+          "green" : "0xFD",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF4",
+          "green" : "0xFD",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/PhotoBrown.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/PhotoBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE2",
+          "green" : "0xF6",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE2",
+          "green" : "0xF6",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/PopUpwhite.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/PopUpwhite.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xFC",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xFC",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/PopUpwhite.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/PopUpwhite.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
+          "alpha" : "0.900",
           "blue" : "0xEB",
           "green" : "0xFC",
           "red" : "0xFF"
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
+          "alpha" : "0.900",
           "blue" : "0xEB",
           "green" : "0xFC",
           "red" : "0xFF"

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/SettingTextGray.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/SettingTextGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x93",
+          "green" : "0x91",
+          "red" : "0x90"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x93",
+          "green" : "0x91",
+          "red" : "0x90"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/SocialBackGray.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/SocialBackGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.120",
+          "blue" : "0xC8",
+          "green" : "0xDC",
+          "red" : "0xE0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.120",
+          "blue" : "0xC8",
+          "green" : "0xDC",
+          "red" : "0xE0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/SocialChartBrown.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/SocialChartBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7B",
+          "green" : "0xCD",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7B",
+          "green" : "0xCD",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/SocialChartGray.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/SocialChartGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBE",
+          "green" : "0xC7",
+          "red" : "0xC9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBE",
+          "green" : "0xC7",
+          "red" : "0xC9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/TextDefaultGray.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/TextDefaultGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC9",
+          "green" : "0xC9",
+          "red" : "0xC9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC9",
+          "green" : "0xC9",
+          "red" : "0xC9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/TodoButtonBrown.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/TodoButtonBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x88",
+          "green" : "0xBE",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x88",
+          "green" : "0xBE",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/TodoModalButton.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/TodoModalButton.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x94",
+          "green" : "0xE1",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x94",
+          "green" : "0xE1",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/TodoNoTextBrown.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/TodoNoTextBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x63",
+          "red" : "0xB7"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x63",
+          "red" : "0xB7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/ToggleOrange.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/ToggleOrange.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7B",
+          "green" : "0xCD",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7B",
+          "green" : "0xCD",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/WanttoModalButton.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/WanttoModalButton.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x99",
+          "green" : "0xD1",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x99",
+          "green" : "0xD1",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/WanttoNoTextBrown.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/WanttoNoTextBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x98",
+          "red" : "0xB7"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x98",
+          "red" : "0xB7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/WanttoYesButtonBrown.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/WanttoYesButtonBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x88",
+          "green" : "0xD3",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x88",
+          "green" : "0xD3",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/WanttoYesTextBrown.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/WanttoYesTextBrown.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDE",
+          "green" : "0xFA",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDE",
+          "green" : "0xFA",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/bracketsGray.colorset/Contents.json
+++ b/PJ2T12_Again12/PJ2T12_Again12/Assets.xcassets/bracketsGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC1",
+          "green" : "0xC0",
+          "red" : "0xC0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC1",
+          "green" : "0xC0",
+          "red" : "0xC0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Extensions/Color.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Extensions/Color.swift
@@ -18,4 +18,30 @@ extension Color {
             opacity: alpha
         )
     }
+    
+    static let AlertBackWhite = Color("AlertBackWhite")
+    static let BackgroundYellow = Color("BackgroundYellow")
+    static let BorderBrown = Color("BorderBrown")
+    static let BracketsGray = Color("BracketsGray")
+    static let CameraBackGray = Color("CameraBackGray")
+    static let CameraGray = Color("CameraGray")
+    static let DefaultBlack = Color("DefaultBlack")
+    static let LoginButtonBrown = Color("LoginButtonBrown")
+    static let NewTodoButtonBrown = Color("NewTodoButtonBrown")
+    static let PhotoBrown = Color("PhotoBrown")
+    static let PopUpwhite = Color("PopUpwhite")
+    static let SettingTextGray = Color("SettingTextGray")
+    static let SocialBackGray = Color("SocialBackGray")
+    static let SocialChartBrown = Color("SocialChartBrown")
+    static let SocialChartGray = Color("SocialChartGray")
+    static let TextDefaultGray = Color("TextDefaultGray")
+    static let TodoButtonBrown = Color("TodoButtonBrown")
+    static let TodoModalButton = Color("TodoModalButton")
+    static let TodoNoTextBrown = Color("TodoNoTextBrown")
+    static let ToggleOrange = Color("ToggleOrange")
+    static let WanttoModalButton = Color("WanttoModalButton")
+    static let WanttoNoTextBrown = Color("WanttoNoTextBrown")
+    static let WanttoYesButtonBrown = Color("WanttoYesButtonBrown")
+    static let WanttoYesTextBrown = Color("WanttoYesTextBrown")
+    
 }


### PR DESCRIPTION
## 이슈번호
🔐close #52  

## 작업사항
- Asset에 Color를 넣었습니다. 
- Extension Color에 정의를 다시 해서 쓰시기 편하게 했습니다. 
- 스크린샷에 Color.ToggleOrange을 적용해서 배경화면이 바뀐것을 확인 해 보시면 됩니다.

## 향후 작업예정
-오전에 Color변환 작업을 하신 후 Hex에 관련된 Color Extention은 삭제하면 좋을것 같습니다. 

## 사용 방법
- Asset에만 Color를 넣는 경우
  Color("AlertBackWhite")이런식으로 Color이름을 ""안에 넣으면 됩니다. -> 오타 생길 위험이 있어 Extension에 한번저 색상을 정의했습니다.
- Extension에 추가한 경우
  Color.AlertBackWhite 이런식으로 바로 사용 하면 됩니다. 스크린샷 공유하겠습니다.

## 참고 자료
https://agate-silence-45e.notion.site/custom-color-dbfa1fd1d1de467f946400db36159c87 (Thanks 은수님 😍)
https://velog.io/@lawn/iOS-SwiftUI-Color-asset-Lawn

## 스크린샷
<img width="697" alt="스크린샷 2023-12-13 오전 1 45 12" src="https://github.com/APP-iOS3rd/PJ2T12_Again12/assets/102846055/1b17920c-7d71-4406-9fcd-bedf227b59c2">

<img width="1041" alt="스크린샷 2023-12-13 오전 1 32 19" src="https://github.com/APP-iOS3rd/PJ2T12_Again12/assets/102846055/7852f26e-c3e3-43c9-ac09-5908d6492129">

