### PR TITLE
Settingview 전체적인 UI 완성하기

### DIFF
--- a/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
+++ b/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
@@ -398,11 +398,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-<<<<<<< HEAD
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
-=======
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
->>>>>>> 2e08addd2e93b192c9b0262b561fa350353354f2
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -434,11 +430,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-<<<<<<< HEAD
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
-=======
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
->>>>>>> 2e08addd2e93b192c9b0262b561fa350353354f2
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
+++ b/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -401,6 +402,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -13,84 +13,83 @@ struct SettingsView: View {
     
     var body: some View {
         NavigationSplitView {
-            ZStack {
-                Color(hex: 0xFFFAE1)
-                    .ignoresSafeArea()
-                    List {
-                        Section() { // 로그인뷰
-                            if !isLogin {
-                                NavigationLink {
-                                    LoginView()
-                                } label: {
-                                    Text("\n 로그인을 해서 개인정보를 입력하세요. \n")
-                                        .foregroundStyle(Color.gray)
-                                }
-                            } else {
-                                AfterLoginView()
-                            }
+            List {
+                // 로그인 뷰
+                Section() {
+                    if !isLogin {
+                        NavigationLink {
+                            LoginView()
+                        } label: {
+                            Text("\n 로그인을 해서 개인정보를 입력하세요. \n")
+                                .foregroundStyle(Color.gray)
                         }
-                        
-                        Section(header: Text("알림 설정")) {
-                            TotalAlarmRow(totalToggle: $totalToggle)
-                            MyAlarmRow(totalToggle: $totalToggle)
-                            FriendsAlarmRow(totalToggle: $totalToggle)
-                        }
-                        
-                        Section(header: Text("테마")) {
-                            if !isLogin {
-                                Text("로그인 하여 각자의 테마를 만들어 보세요.")
-                                    .foregroundStyle(Color.gray)
-                            } else {
-                                NavigationLink {
-                                    DetailView()
-                                } label: {
-                                    Text("커스텀 테마를 골라보세요.")
-                                }
-                            }
-                        }
-                        
-                        Section(header: Text("설정")) {
-                            NavigationLink {
-                                DetailView()
-                            } label: {
-                                Text("공지사항")
-                            }
-                            NavigationLink {
-                                DetailView()
-                            } label: {
-                                Text("정보")
-                            }
-                            NavigationLink {
-                                DetailView()
-                            } label: {
-                                Text("문의사항")
-                            }
-                        }
-                        
-                        Section(header: Text("계정 관리")) {
-                            NavigationLink {
-                                DetailView()
-                            } label: {
-                                Text("로그아웃")
-                            }
-                            NavigationLink {
-                                DetailView()
-                            } label: {
-                                Text("회원 탈퇴")
-                            }
+                    } else {
+                        ProfileView()
+                    }
+                }
+                
+                Section(header: Text("알림 설정")) {
+                    TotalAlarmRow(totalToggle: $totalToggle)
+                    MyAlarmRow(totalToggle: $totalToggle)
+                    FriendsAlarmRow(totalToggle: $totalToggle)
+                }
+                
+                Section(header: Text("테마")) {
+                    if !isLogin {
+                        Text("로그인 하여 각자의 테마를 만들어 보세요.")
+                            .foregroundStyle(Color.gray)
+                    } else {
+                        NavigationLink {
+                            DetailView()
+                        } label: {
+                            Text("커스텀 테마를 골라보세요.")
                         }
                     }
-                    .listStyle(.grouped)
-                    .background(Color(hex: 0xFFFAE1))
-                    .scrollContentBackground(.hidden)
                 }
-                .navigationTitle("설정")
+                
+                Section(header: Text("설정")) {
+                    NavigationLink {
+                        DetailView()
+                    } label: {
+                        Text("공지사항")
+                    }
+                    NavigationLink {
+                        DetailView()
+                    } label: {
+                        Text("정보")
+                    }
+                    NavigationLink {
+                        DetailView()
+                    } label: {
+                        Text("문의사항")
+                    }
+                }
+                
+                Section(header: Text("계정 관리")) {
+                    NavigationLink {
+                        DetailView()
+                    } label: {
+                        Text("로그아웃")
+                    }
+                    NavigationLink {
+                        DetailView()
+                    } label: {
+                        Text("회원 탈퇴")
+                    }
+                }
+            }
+            .listStyle(.grouped)
+            .background(Color(hex: 0xFFFAE1))
+            .scrollContentBackground(.hidden)
+            
+            .navigationTitle("설정")
         } detail: {
             Text("")
         }
     }
 }
 
+// 로그인 하는뷰
 struct LoginView: View {
     @State private var ID = ""
     @State private var password = ""
@@ -121,7 +120,8 @@ struct LoginView: View {
     }
 }
 
-struct AfterLoginView: View {
+// 로그인 이후 뷰
+struct ProfileView: View {
     @State private var nickname = "투두리"
     var body: some View {
         HStack {
@@ -136,6 +136,7 @@ struct AfterLoginView: View {
     }
 }
 
+// 전체 알림 Row
 struct TotalAlarmRow: View {
     @Binding var totalToggle: Bool
     
@@ -149,6 +150,7 @@ struct TotalAlarmRow: View {
     }
 }
 
+// 나의 알림 Row
 struct MyAlarmRow: View {
     @State private var myToggle = true
     @Binding var totalToggle: Bool
@@ -164,6 +166,7 @@ struct MyAlarmRow: View {
     }
 }
 
+// 친구 알림 Row
 struct FriendsAlarmRow: View {
     @State private var friendsToggle = true
     @Binding var totalToggle: Bool

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @State private var totalToggle = true
     @State private var isLogin = true
     @State private var nickname = "투두리"
+    @State private var profileImage = UIImage()
     
     var body: some View {
         NavigationSplitView {
@@ -26,9 +27,9 @@ struct SettingsView: View {
                         }
                     } else {
                         NavigationLink {
-                            ProfileEditView(nickname: $nickname)
+                            ProfileEditView(nickname: $nickname, profileImage: $profileImage)
                         } label: {
-                            ProfileView(nickname: $nickname)
+                            ProfileView(nickname: $nickname, profileImage: $profileImage)
                         }
                     }
                 }
@@ -128,14 +129,31 @@ struct LoginView: View {
 // 로그인 이후 뷰
 struct ProfileView: View {
     @Binding var nickname: String
+    @Binding var profileImage: UIImage
+    
     var body: some View {
         HStack {
-            Image(systemName: "hare.fill")
-                .resizable()
-                .foregroundStyle(Color.pink)
-                .frame(width: 100, height: 100)
-                .clipShape(Circle())
-                .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
+//            Image(systemName: "hare.fill")
+//                .resizable()
+//                .foregroundStyle(Color.pink)
+//                .frame(width: 100, height: 100)
+//                .clipShape(Circle())
+//                .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
+            if profileImage.size.width != 0 && profileImage.size.height != 0 {
+                Image(uiImage: profileImage)
+                    .resizable()
+                    .frame(width: 100, height: 100)
+                    .scaledToFit()
+                    .clipShape(Circle())
+                    .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
+            } else {
+                Image(systemName: "hare.fill")
+                    .resizable()
+                    .frame(width: 100, height: 100)
+                    .foregroundColor(.pink)
+                    .clipShape(Circle())
+                    .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
+            }
             VStack (alignment: .leading) {
                 Text("닉네임: \(nickname)")
                 Text("")
@@ -151,7 +169,7 @@ struct ProfileEditView: View {
     @StateObject private var viewModel = EditViewModel()
     @State private var checkSave = false
     @State private var openPhoto = false
-    @State private var image = UIImage()
+    @Binding var profileImage: UIImage
     
     var body: some View {
         ZStack {
@@ -165,11 +183,6 @@ struct ProfileEditView: View {
                 }
                 Spacer()
                 HStack {
-//                    Image(systemName: "hare.fill")
-//                        .resizable()
-//                        .foregroundStyle(Color.pink)
-//                        .frame(width: 100, height: 100)
-//                        .padding()
                     HStack {
                         Button(action: {
                             viewModel.checkAlbumPermission()
@@ -179,8 +192,8 @@ struct ProfileEditView: View {
                         }) {
                             ZStack {
                                 if !checkSave {
-                                    if image.size != CGSize.zero {
-                                        Image(uiImage: image)
+                                    if profileImage.size != CGSize.zero {
+                                        Image(uiImage: profileImage)
                                             .resizable()
                                             .frame(width: 100, height: 100)
                                             .scaledToFit()
@@ -202,7 +215,7 @@ struct ProfileEditView: View {
                             }
                         }
                         .sheet(isPresented: $openPhoto) {
-                            ImagePicker(sourceType: .photoLibrary, selectedImage: self.$image)
+                            ImagePicker(sourceType: .photoLibrary, selectedImage: self.$profileImage)
                         }
                         .padding()
                         Spacer()

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -135,10 +135,7 @@ struct ProfileView: View {
                 .foregroundStyle(Color.pink)
                 .frame(width: 100, height: 100)
                 .clipShape(Circle())
-                .overlay(
-                    Circle()
-                        .stroke(Color.yellow, lineWidth: 1)
-                )
+                .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
             VStack (alignment: .leading) {
                 Text("닉네임: \(nickname)")
                 Text("")
@@ -151,6 +148,10 @@ struct ProfileView: View {
 
 struct ProfileEditView: View {
     @Binding var nickname: String
+    @StateObject private var viewModel = EditViewModel()
+    @State private var checkSave = false
+    @State private var openPhoto = false
+    @State private var image = UIImage()
     
     var body: some View {
         ZStack {
@@ -164,11 +165,49 @@ struct ProfileEditView: View {
                 }
                 Spacer()
                 HStack {
-                    Image(systemName: "hare.fill")
-                        .resizable()
-                        .foregroundStyle(Color.pink)
-                        .frame(width: 100, height: 100)
+//                    Image(systemName: "hare.fill")
+//                        .resizable()
+//                        .foregroundStyle(Color.pink)
+//                        .frame(width: 100, height: 100)
+//                        .padding()
+                    HStack {
+                        Button(action: {
+                            viewModel.checkAlbumPermission()
+                            if viewModel.albumPermissionGranted {
+                                self.openPhoto = true
+                            }
+                        }) {
+                            ZStack {
+                                if !checkSave {
+                                    if image.size != CGSize.zero {
+                                        Image(uiImage: image)
+                                            .resizable()
+                                            .frame(width: 100, height: 100)
+                                            .scaledToFit()
+                                            .clipShape(Circle())
+                                            .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
+                                    } else {
+                                        Image(systemName: "hare.fill")
+                                            .resizable()
+                                            .frame(width: 100, height: 100)
+                                            .foregroundColor(.pink)
+                                            .clipShape(Circle())
+                                            .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
+                                    }
+                                }
+                                Image(systemName: "camera.circle")
+                                    .font(/*@START_MENU_TOKEN@*/.title/*@END_MENU_TOKEN@*/)
+                                    .foregroundColor(.gray)
+                                    .offset(x: 40, y: 40)
+                            }
+                        }
+                        .sheet(isPresented: $openPhoto) {
+                            ImagePicker(sourceType: .photoLibrary, selectedImage: self.$image)
+                        }
                         .padding()
+                        Spacer()
+                            
+                    }
                     VStack (alignment: .leading) {
                         Text("닉네임")
                         TextField("닉네임을 설정해주세요.", text: $nickname)

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -9,8 +9,44 @@ import SwiftUI
 
 struct SettingsView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationView {
+            ZStack {
+                Color(hex: 0xFFFAE1)
+                    .ignoresSafeArea()
+                List {
+                    Section(header: Text("알림 설정")) {
+                        TaskRow()
+                        TaskRow()
+                        TaskRow()
+                        TaskRow()
+                    }
+                    Section(header: Text("테마")) {
+                        TaskRow()
+                    }
+                    Section(header: Text("설정")) {
+                        TaskRow()
+                        TaskRow()
+                        TaskRow()
+                    }
+                    Section(header: Text("계정 관리")) {
+                        TaskRow()
+                        TaskRow()
+                    }
+                }
+                .listStyle(.grouped)
+                
+            }
+            .navigationBarTitle("설정")
+        }
     }
+}
+
+struct TaskRow: View {
+  var body: some View {
+      HStack {
+          Text("Test")
+      }
+  }
 }
 
 #Preview {

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -72,6 +72,8 @@ struct SettingsView: View {
                         }
                     }
                     .listStyle(.grouped)
+                    .background(Color(hex: 0xFFFAE1))
+                    .scrollContentBackground(.hidden)
                 }
             
             .navigationTitle("설정")

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -103,18 +103,6 @@ struct LoginView: View {
             Color(hex: 0xFFFAE1)
                 .ignoresSafeArea()
             VStack(spacing: 20) {
-                HStack {
-                    Text("ID             ")
-                        .foregroundStyle(Color(hex: 0x432D00))
-                    TextField("ID", text: $ID)
-                        .textFieldStyle(.roundedBorder)
-                }
-                HStack {
-                    Text("Password")
-                        .foregroundStyle(Color(hex: 0x432D00))
-                    TextField("Password", text: $password)
-                        .textFieldStyle(.roundedBorder)
-                }
                 Button(action: {
                     login()
                     isLogin = true
@@ -126,6 +114,27 @@ struct LoginView: View {
                 })
                 .padding()
                 .background(Color(hex: 0xFEE500))
+                .cornerRadius(10)
+                Button(action: {}, label: {
+                    HStack {
+                        Text("G  ")
+                            .fontWeight(.heavy)
+                        Text("Sign in with Google")
+                    }
+                })
+                .padding()
+                .background(Color(hex: 0xFFFFFF))
+                .cornerRadius(10)
+                Button(action: {}, label: {
+                    HStack {
+                        Text("N  ")
+                            .fontWeight(.heavy)
+                        Text("네이버 로그인")
+                    }
+                    .foregroundStyle(Color.white)
+                })
+                .padding()
+                .background(Color(hex: 0x03C75A))
                 .cornerRadius(10)
             }
             .padding()

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -20,14 +20,14 @@ struct SettingsView: View {
                 Section() {
                     if !isLogin {
                         NavigationLink {
-                            LoginView()
+                            LoginView(isLogin: $isLogin)
                         } label: {
                             Text("\n 로그인을 해서 더 많은 기능을 사용해보세요. \n")
                                 .foregroundStyle(Color.gray)
                         }
                     } else {
                         NavigationLink {
-                            ProfileEditView(nickname: $nickname, profileImage: $profileImage)
+                            ProfileEditView(nickname: $nickname, profileImage: $profileImage, isLogin: $isLogin)
                         } label: {
                             ProfileView(nickname: $nickname, profileImage: $profileImage)
                         }
@@ -96,6 +96,7 @@ struct SettingsView: View {
 struct LoginView: View {
     @State private var ID = ""
     @State private var password = ""
+    @Binding var isLogin: Bool
     
     var body: some View {
         ZStack {
@@ -114,7 +115,10 @@ struct LoginView: View {
                     TextField("Password", text: $password)
                         .textFieldStyle(.roundedBorder)
                 }
-                Button(action: {}, label: {
+                Button(action: {
+                    login()
+                    isLogin = true
+                }, label: {
                     HStack {
                         Image(systemName: "message.fill")
                         Text("카카오 로그인")
@@ -168,6 +172,7 @@ struct ProfileEditView: View {
     @State private var checkSave = false
     @State private var openPhoto = false
     @Binding var profileImage: UIImage
+    @Binding var isLogin: Bool
     
     var body: some View {
         List {
@@ -224,7 +229,10 @@ struct ProfileEditView: View {
             .listRowBackground(Color(hex: 0xFFFEF6))
             
             Section(header: Text("계정 관리")) {
-                Button("로그아웃", action: logout)
+                Button("로그아웃", action: {
+                    logout()
+                    isLogin = false
+                })
                 
                 NavigationLink {
                     WithDrawView()
@@ -241,9 +249,15 @@ struct ProfileEditView: View {
         .scrollContentBackground(.hidden)
     }
 }
+
+func login() {
+    print("logout")
+}
+
 func logout() {
     print("logout")
 }
+
 func profileSave() {
     print("profile saved")
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -51,6 +51,7 @@ struct SettingsView: View {
                             ThemeView()
                         } label: {
                             Text("커스텀 테마를 골라보세요.")
+                                .foregroundStyle(Color(hex: 0x432D00))
                         }
                     }
                 }
@@ -61,11 +62,13 @@ struct SettingsView: View {
                         NoticeView()
                     } label: {
                         Text("공지사항")
+                            .foregroundStyle(Color(hex: 0x432D00))
                     }
                     NavigationLink {
                         SettingDetailView()
                     } label: {
                         Text("정보")
+                            .foregroundStyle(Color(hex: 0x432D00))
                     }
                     NavigationLink {
                         // QnAView() 가 맞음
@@ -73,6 +76,7 @@ struct SettingsView: View {
                         EditView()
                     } label: {
                         Text("문의사항")
+                            .foregroundStyle(Color(hex: 0x432D00))
                     }
                 }
                 .listRowBackground(Color(hex: 0xFFFEF6))
@@ -82,11 +86,13 @@ struct SettingsView: View {
                         LogoutView()
                     } label: {
                         Text("로그아웃")
+                            .foregroundStyle(Color(hex: 0x432D00))
                     }
                     NavigationLink {
                         WithDrawView()
                     } label: {
                         Text("회원 탈퇴")
+                            .foregroundStyle(Color(hex: 0x432D00))
                     }
                 }
                 .listRowBackground(Color(hex: 0xFFFEF6))
@@ -94,11 +100,11 @@ struct SettingsView: View {
             .listStyle(.grouped)
             .background(Color(hex: 0xFFFAE1))
             .scrollContentBackground(.hidden)
-            
             .navigationTitle("설정")
         } detail: {
             Text("")
         }
+        .accentColor(Color(hex: 0x432D00))
     }
 }
 
@@ -159,6 +165,7 @@ struct ProfileView: View {
                 Text("닉네임: \(nickname)")
                 Text("")
             }
+            .foregroundStyle(Color(hex: 0x432D00))
             .padding()
         }
         .padding()
@@ -180,6 +187,7 @@ struct ProfileEditView: View {
                 HStack {
                     Spacer()
                     Button("저장", action: profileSave)
+                        .foregroundStyle(Color(hex: 0x432D00))
                         .padding()
                 }
                 Spacer()
@@ -223,10 +231,11 @@ struct ProfileEditView: View {
                             
                     }
                     VStack (alignment: .leading) {
-                        Text("닉네임")
+                        Text(" 닉네임")
                         TextField("닉네임을 설정해주세요.", text: $nickname)
                             .textFieldStyle(.roundedBorder)
                     }
+                    .foregroundStyle(Color(hex: 0x432D00))
                     .padding()
                 }
                 .background(Color.white)
@@ -248,6 +257,7 @@ struct TotalAlarmRow: View {
         HStack {
             Toggle(isOn: $totalToggle, label: {
                 Text("전체 알림")
+                    .foregroundStyle(Color(hex: 0x432D00))
                 Text("전체 알림을 조절할 수 있습니다.")
             })
             .tint(Color(hex: 0xFFCD7B))
@@ -265,6 +275,7 @@ struct MyAlarmRow: View {
         HStack {
             Toggle(isOn: $myToggle, label: {
                 Text("나의 알림")
+                    .foregroundStyle(Color(hex: 0x432D00))
                 Text("나의 일정 알림을 조절할 수 있습니다.")
             })
             .disabled(!totalToggle)
@@ -282,6 +293,7 @@ struct FriendsAlarmRow: View {
         HStack {
             Toggle(isOn: $friendsToggle, label: {
                 Text("친구 알림")
+                    .foregroundStyle(Color(hex: 0x432D00))
                 Text("친구들이 보내는 알림을 조절할 수 있습니다.")
             })
             .disabled(!totalToggle)

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -251,7 +251,7 @@ struct ProfileEditView: View {
 }
 
 func login() {
-    print("logout")
+    print("login")
 }
 
 func logout() {

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -37,7 +37,16 @@ struct SettingsView: View {
                         }
                         
                         Section(header: Text("테마")) {
-                            ThemeRow()
+                            if !isLogin {
+                                Text("로그인 하여 각자의 테마를 만들어 보세요.")
+                                    .foregroundStyle(Color.gray)
+                            } else {
+                                NavigationLink {
+                                    DetailView()
+                                } label: {
+                                    Text("커스텀 테마를 골라보세요.")
+                                }
+                            }
                         }
                         
                         Section(header: Text("설정")) {
@@ -75,8 +84,7 @@ struct SettingsView: View {
                     .background(Color(hex: 0xFFFAE1))
                     .scrollContentBackground(.hidden)
                 }
-            
-            .navigationTitle("설정")
+                .navigationTitle("설정")
         } detail: {
             Text("")
         }
@@ -167,15 +175,6 @@ struct FriendsAlarmRow: View {
                 Text("친구들이 보내는 알림을 조절할 수 있습니다.")
             })
             .disabled(!totalToggle)
-        }
-    }
-}
-
-struct ThemeRow: View {
-    var body: some View {
-        HStack {
-            Text("로그인 하여 각자의 테마를 만들어 보세요.")
-                .foregroundStyle(Color.gray)
         }
     }
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @State private var totalToggle = true
-    @State private var isLogin = true
+    @State private var isLogin = false
     @State private var nickname = "투두리"
     @State private var profileImage = UIImage()
     
@@ -22,7 +22,7 @@ struct SettingsView: View {
                         NavigationLink {
                             LoginView()
                         } label: {
-                            Text("\n 로그인을 해서 개인정보를 입력하세요. \n")
+                            Text("\n 로그인을 해서 더 많은 기능을 사용해보세요. \n")
                                 .foregroundStyle(Color.gray)
                         }
                     } else {
@@ -117,24 +117,30 @@ struct LoginView: View {
         ZStack {
             Color(hex: 0xFFFAE1)
                 .ignoresSafeArea()
-            VStack {
+            VStack(spacing: 20) {
                 HStack {
                     Text("ID             ")
+                        .foregroundStyle(Color(hex: 0x432D00))
                     TextField("ID", text: $ID)
                         .textFieldStyle(.roundedBorder)
                 }
-                .padding()
                 HStack {
                     Text("Password")
+                        .foregroundStyle(Color(hex: 0x432D00))
                     TextField("Password", text: $password)
                         .textFieldStyle(.roundedBorder)
                 }
+                Button(action: {}, label: {
+                    HStack {
+                        Image(systemName: "message.fill")
+                        Text("카카오 로그인")
+                    }
+                })
                 .padding()
-                Image(systemName: "airplane") // 카카오 연동
-                    .resizable()
-                    .frame(width: 50, height: 50)
+                .background(Color(hex: 0xFEE500))
+                .cornerRadius(10)
             }
-            .padding(30)
+            .padding()
         }
     }
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -33,12 +33,14 @@ struct SettingsView: View {
                         }
                     }
                 }
+                .listRowBackground(Color(hex: 0xFFFEF6))
                 
                 Section(header: Text("알림 설정")) {
                     TotalAlarmRow(totalToggle: $totalToggle)
                     MyAlarmRow(totalToggle: $totalToggle)
                     FriendsAlarmRow(totalToggle: $totalToggle)
                 }
+                .listRowBackground(Color(hex: 0xFFFEF6))
                 
                 Section(header: Text("테마")) {
                     if !isLogin {
@@ -52,6 +54,7 @@ struct SettingsView: View {
                         }
                     }
                 }
+                .listRowBackground(Color(hex: 0xFFFEF6))
                 
                 Section(header: Text("설정")) {
                     NavigationLink {
@@ -65,11 +68,14 @@ struct SettingsView: View {
                         Text("정보")
                     }
                     NavigationLink {
+                        // QnAView() 가 맞음
+                        // EditView() 확인용
                         EditView()
                     } label: {
                         Text("문의사항")
                     }
                 }
+                .listRowBackground(Color(hex: 0xFFFEF6))
                 
                 Section(header: Text("계정 관리")) {
                     NavigationLink {
@@ -83,6 +89,7 @@ struct SettingsView: View {
                         Text("회원 탈퇴")
                     }
                 }
+                .listRowBackground(Color(hex: 0xFFFEF6))
             }
             .listStyle(.grouped)
             .background(Color(hex: 0xFFFAE1))
@@ -133,12 +140,6 @@ struct ProfileView: View {
     
     var body: some View {
         HStack {
-//            Image(systemName: "hare.fill")
-//                .resizable()
-//                .foregroundStyle(Color.pink)
-//                .frame(width: 100, height: 100)
-//                .clipShape(Circle())
-//                .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
             if profileImage.size.width != 0 && profileImage.size.height != 0 {
                 Image(uiImage: profileImage)
                     .resizable()
@@ -152,7 +153,7 @@ struct ProfileView: View {
                     .frame(width: 100, height: 100)
                     .foregroundColor(.pink)
                     .clipShape(Circle())
-                    .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
+                    .overlay(Circle().stroke(Color(hex: 0xE5F5FF), lineWidth: 1))
             }
             VStack (alignment: .leading) {
                 Text("닉네임: \(nickname)")
@@ -198,18 +199,18 @@ struct ProfileEditView: View {
                                             .frame(width: 100, height: 100)
                                             .scaledToFit()
                                             .clipShape(Circle())
-                                            .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
+                                            .overlay(Circle().stroke(Color(hex: 0xE5F5FF), lineWidth: 1))
                                     } else {
                                         Image(systemName: "hare.fill")
                                             .resizable()
                                             .frame(width: 100, height: 100)
                                             .foregroundColor(.pink)
                                             .clipShape(Circle())
-                                            .overlay(Circle().stroke(Color.yellow, lineWidth: 1))
+                                            .overlay(Circle().stroke(Color(hex: 0xE5F5FF), lineWidth: 1))
                                     }
                                 }
                                 Image(systemName: "camera.circle")
-                                    .font(/*@START_MENU_TOKEN@*/.title/*@END_MENU_TOKEN@*/)
+                                    .font(.title)
                                     .foregroundColor(.gray)
                                     .offset(x: 40, y: 40)
                             }
@@ -249,7 +250,9 @@ struct TotalAlarmRow: View {
                 Text("전체 알림")
                 Text("전체 알림을 조절할 수 있습니다.")
             })
+            .tint(Color(hex: 0xFFCD7B))
         }
+        
     }
 }
 
@@ -265,6 +268,7 @@ struct MyAlarmRow: View {
                 Text("나의 일정 알림을 조절할 수 있습니다.")
             })
             .disabled(!totalToggle)
+            .tint(Color(hex: 0xFFCD7B))
         }
     }
 }
@@ -281,6 +285,7 @@ struct FriendsAlarmRow: View {
                 Text("친구들이 보내는 알림을 조절할 수 있습니다.")
             })
             .disabled(!totalToggle)
+            .tint(Color(hex: 0xFFCD7B))
         }
     }
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -64,7 +64,7 @@ struct SettingsView: View {
                         Text("정보")
                     }
                     NavigationLink {
-                        QnAView()
+                        EditView()
                     } label: {
                         Text("문의사항")
                     }
@@ -130,12 +130,20 @@ struct ProfileView: View {
     @Binding var nickname: String
     var body: some View {
         HStack {
-            Image(systemName: "airplane")
-                .frame(width: 100)
+            Image(systemName: "hare.fill")
+                .resizable()
+                .foregroundStyle(Color.pink)
+                .frame(width: 100, height: 100)
+                .clipShape(Circle())
+                .overlay(
+                    Circle()
+                        .stroke(Color.yellow, lineWidth: 1)
+                )
             VStack (alignment: .leading) {
                 Text("닉네임: \(nickname)")
                 Text("")
             }
+            .padding()
         }
         .padding()
     }
@@ -143,25 +151,40 @@ struct ProfileView: View {
 
 struct ProfileEditView: View {
     @Binding var nickname: String
+    
     var body: some View {
         ZStack {
             Color(hex: 0xFFFAE1)
                 .ignoresSafeArea()
             VStack {
                 HStack {
-                    Image(systemName: "airplane")
-                        .frame(width: 100)
+                    Spacer()
+                    Button("저장", action: profileSave)
+                        .padding()
+                }
+                Spacer()
+                HStack {
+                    Image(systemName: "hare.fill")
+                        .resizable()
+                        .foregroundStyle(Color.pink)
+                        .frame(width: 100, height: 100)
+                        .padding()
                     VStack (alignment: .leading) {
                         Text("닉네임")
                         TextField("닉네임을 설정해주세요.", text: $nickname)
                             .textFieldStyle(.roundedBorder)
                     }
+                    .padding()
                 }
-                
+                .background(Color.white)
+                Spacer()
+                Spacer()
             }
-            .padding()
         }
     }
+}
+
+func profileSave() {
 }
 
 // 전체 알림 Row
@@ -283,7 +306,6 @@ struct WithDrawView: View {
         }
     }
 }
-
 
 #Preview {
     SettingsView()

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -8,20 +8,21 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @State private var totalToggle = true
+    
     var body: some View {
         NavigationView {
             ZStack {
                 NavigationSplitView {
                     List {
-                        Rectangle() // 로그인 뷰
-                            .frame(width: 400, height: 100)
-                            .foregroundStyle(Color.white)
-                        
+                        Section() {
+                            LoginRow() // 로그인뷰
+                        }
                         Section(header: Text("알림 설정")) {
-                            TotalAlarmRow()
-                            MyAlarmRow()
-                            FriendsAlarmRow()
-                            NightAlarmRow()
+                            TotalAlarmRow(totalToggle: $totalToggle)
+                            MyAlarmRow(totalToggle: $totalToggle)
+                            FriendsAlarmRow(totalToggle: $totalToggle)
+                            NightAlarmRow(totalToggle: $totalToggle)
                         }
                         Section(header: Text("테마")) {
                             ThemeRow()
@@ -66,8 +67,18 @@ struct SettingsView: View {
     }
 }
 
+struct LoginRow: View {
+    
+    var body: some View {
+        VStack {
+            Text("로그인을 해서 개인정보를 입력하세요.")
+                .foregroundStyle(Color.gray)
+        }
+    }
+}
+
 struct TotalAlarmRow: View {
-    @State private var totalToggle = true
+    @Binding var totalToggle: Bool
     
     var body: some View {
         HStack {
@@ -81,6 +92,7 @@ struct TotalAlarmRow: View {
 
 struct MyAlarmRow: View {
     @State private var myToggle = true
+    @Binding var totalToggle: Bool
     
     var body: some View {
         HStack {
@@ -88,12 +100,14 @@ struct MyAlarmRow: View {
                 Text("나의 알림")
                 Text("나의 일정 알림을 조절할 수 있습니다.")
             })
+            .disabled(!totalToggle)
         }
     }
 }
 
 struct FriendsAlarmRow: View {
     @State private var friendsToggle = true
+    @Binding var totalToggle: Bool
     
     var body: some View {
         HStack {
@@ -101,12 +115,14 @@ struct FriendsAlarmRow: View {
                 Text("친구 알림")
                 Text("친구들이 보내는 알림을 조절할 수 있습니다.")
             })
+            .disabled(!totalToggle)
         }
     }
 }
 
 struct NightAlarmRow: View {
     @State private var nightToggle = true
+    @Binding var totalToggle: Bool
     
     var body: some View {
         HStack {
@@ -114,6 +130,7 @@ struct NightAlarmRow: View {
                 Text("야간 알림")
                 Text("야간에 오는 알림을 조절할 수 있습니다.")
             })
+            .disabled(!totalToggle)
         }
     }
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -11,42 +11,120 @@ struct SettingsView: View {
     var body: some View {
         NavigationView {
             ZStack {
-                Color(hex: 0xFFFAE1)
-                    .ignoresSafeArea()
-                List {
-                    Section(header: Text("알림 설정")) {
-                        TaskRow()
-                        TaskRow()
-                        TaskRow()
-                        TaskRow()
+                NavigationSplitView {
+                    List {
+                        Rectangle() // 로그인 뷰
+                            .frame(width: 400, height: 100)
+                            .foregroundStyle(Color.white)
+                        
+                        Section(header: Text("알림 설정")) {
+                            TotalAlarmRow()
+                            MyAlarmRow()
+                            FriendsAlarmRow()
+                            NightAlarmRow()
+                        }
+                        Section(header: Text("테마")) {
+                            ThemeRow()
+                        }
+                        Section(header: Text("설정")) {
+                            NavigationLink {
+                                DetailView()
+                            } label: {
+                                Text("공지사항")
+                            }
+                            NavigationLink {
+                                DetailView()
+                            } label: {
+                                Text("정보")
+                            }
+                            NavigationLink {
+                                DetailView()
+                            } label: {
+                                Text("문의사항")
+                            }
+                        }
+                        Section(header: Text("계정 관리")) {
+                            NavigationLink {
+                                DetailView()
+                            } label: {
+                                Text("로그아웃")
+                            }
+                            NavigationLink {
+                                DetailView()
+                            } label: {
+                                Text("회원 탈퇴")
+                            }
+                        }
                     }
-                    Section(header: Text("테마")) {
-                        TaskRow()
-                    }
-                    Section(header: Text("설정")) {
-                        TaskRow()
-                        TaskRow()
-                        TaskRow()
-                    }
-                    Section(header: Text("계정 관리")) {
-                        TaskRow()
-                        TaskRow()
-                    }
+                    .listStyle(.grouped)
+                } detail: {
+                    Text("")
                 }
-                .listStyle(.grouped)
-                
             }
             .navigationBarTitle("설정")
         }
     }
 }
 
-struct TaskRow: View {
-  var body: some View {
-      HStack {
-          Text("Test")
-      }
-  }
+struct TotalAlarmRow: View {
+    @State private var totalToggle = true
+    
+    var body: some View {
+        HStack {
+            Toggle(isOn: $totalToggle, label: {
+                Text("전체 알림")
+                Text("전체 알림을 조절할 수 있습니다.")
+            })
+        }
+    }
+}
+
+struct MyAlarmRow: View {
+    @State private var myToggle = true
+    
+    var body: some View {
+        HStack {
+            Toggle(isOn: $myToggle, label: {
+                Text("나의 알림")
+                Text("나의 일정 알림을 조절할 수 있습니다.")
+            })
+        }
+    }
+}
+
+struct FriendsAlarmRow: View {
+    @State private var friendsToggle = true
+    
+    var body: some View {
+        HStack {
+            Toggle(isOn: $friendsToggle, label: {
+                Text("친구 알림")
+                Text("친구들이 보내는 알림을 조절할 수 있습니다.")
+            })
+        }
+    }
+}
+
+struct NightAlarmRow: View {
+    @State private var nightToggle = true
+    
+    var body: some View {
+        HStack {
+            Toggle(isOn: $nightToggle, label: {
+                Text("야간 알림")
+                Text("야간에 오는 알림을 조절할 수 있습니다.")
+            })
+        }
+    }
+}
+
+struct ThemeRow: View {
+    var body: some View {
+        HStack {
+            Text("로그인 하여 각자의 테마를 만들어 보세요.")
+                .foregroundStyle(Color.gray)
+        }
+    }
 }
 
 #Preview {

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -80,22 +80,6 @@ struct SettingsView: View {
                     }
                 }
                 .listRowBackground(Color(hex: 0xFFFEF6))
-                
-                Section(header: Text("계정 관리")) {
-                    NavigationLink {
-                        LogoutView()
-                    } label: {
-                        Text("로그아웃")
-                            .foregroundStyle(Color(hex: 0x432D00))
-                    }
-                    NavigationLink {
-                        WithDrawView()
-                    } label: {
-                        Text("회원 탈퇴")
-                            .foregroundStyle(Color(hex: 0x432D00))
-                    }
-                }
-                .listRowBackground(Color(hex: 0xFFFEF6))
             }
             .listStyle(.grouped)
             .background(Color(hex: 0xFFFAE1))
@@ -186,17 +170,8 @@ struct ProfileEditView: View {
     @Binding var profileImage: UIImage
     
     var body: some View {
-        ZStack {
-            Color(hex: 0xFFFAE1)
-                .ignoresSafeArea()
-            VStack {
-                HStack {
-                    Spacer()
-                    Button("저장", action: profileSave)
-                        .foregroundStyle(Color(hex: 0x432D00))
-                        .padding()
-                }
-                Spacer()
+        List {
+            Section(header: Text("나의 정보")) {
                 HStack {
                     HStack {
                         Button(action: {
@@ -234,7 +209,7 @@ struct ProfileEditView: View {
                         }
                         .padding()
                         Spacer()
-                            
+                        
                     }
                     VStack (alignment: .leading) {
                         Text(" 닉네임")
@@ -245,14 +220,32 @@ struct ProfileEditView: View {
                     .padding()
                 }
                 .background(Color.white)
-                Spacer()
-                Spacer()
             }
+            .listRowBackground(Color(hex: 0xFFFEF6))
+            
+            Section(header: Text("계정 관리")) {
+                Button("로그아웃", action: logout)
+                
+                NavigationLink {
+                    WithDrawView()
+                } label: {
+                    Text("회원 탈퇴")
+                        .foregroundStyle(Color(hex: 0x432D00))
+                }
+            }
+            .listRowBackground(Color(hex: 0xFFFEF6))
+            
         }
+        .listStyle(.grouped)
+        .background(Color(hex: 0xFFFAE1))
+        .scrollContentBackground(.hidden)
     }
 }
-
+func logout() {
+    print("logout")
+}
 func profileSave() {
+    print("profile saved")
 }
 
 // 전체 알림 Row
@@ -353,18 +346,6 @@ struct QnAView: View {
                 .ignoresSafeArea()
             VStack {
                 Text("문의사항 뷰")
-            }
-        }
-    }
-}
-
-struct LogoutView: View {
-    var body: some View {
-        ZStack {
-            Color(hex: 0xFFFAE1)
-                .ignoresSafeArea()
-            VStack {
-                Text("로그아웃 뷰")
             }
         }
     }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -9,24 +9,37 @@ import SwiftUI
 
 struct SettingsView: View {
     @State private var totalToggle = true
+    @State private var isLogin = false
     
     var body: some View {
-        NavigationView {
+        NavigationSplitView {
             ZStack {
-                NavigationSplitView {
+                Color(hex: 0xFFFAE1)
+                    .ignoresSafeArea()
                     List {
-                        Section() {
-                            LoginRow() // 로그인뷰
+                        Section() { // 로그인뷰
+                            if !isLogin {
+                                NavigationLink {
+                                    LoginView()
+                                } label: {
+                                    Text("\n 로그인을 해서 개인정보를 입력하세요. \n")
+                                        .foregroundStyle(Color.gray)
+                                }
+                            } else {
+                                AfterLoginView()
+                            }
                         }
+                        
                         Section(header: Text("알림 설정")) {
                             TotalAlarmRow(totalToggle: $totalToggle)
                             MyAlarmRow(totalToggle: $totalToggle)
                             FriendsAlarmRow(totalToggle: $totalToggle)
-                            NightAlarmRow(totalToggle: $totalToggle)
                         }
+                        
                         Section(header: Text("테마")) {
                             ThemeRow()
                         }
+                        
                         Section(header: Text("설정")) {
                             NavigationLink {
                                 DetailView()
@@ -44,6 +57,7 @@ struct SettingsView: View {
                                 Text("문의사항")
                             }
                         }
+                        
                         Section(header: Text("계정 관리")) {
                             NavigationLink {
                                 DetailView()
@@ -58,21 +72,56 @@ struct SettingsView: View {
                         }
                     }
                     .listStyle(.grouped)
-                } detail: {
-                    Text("")
                 }
-            }
-            .navigationBarTitle("설정")
+            
+            .navigationTitle("설정")
+        } detail: {
+            Text("")
         }
     }
 }
 
-struct LoginRow: View {
+struct LoginView: View {
+    @State private var ID = ""
+    @State private var password = ""
     
     var body: some View {
-        VStack {
-            Text("로그인을 해서 개인정보를 입력하세요.")
-                .foregroundStyle(Color.gray)
+        ZStack {
+            Color(hex: 0xFFFAE1)
+                .ignoresSafeArea()
+            VStack {
+                HStack {
+                    Text("ID             ")
+                    TextField("ID", text: $ID)
+                        .textFieldStyle(.roundedBorder)
+                }
+                .padding()
+                HStack {
+                    Text("Password")
+                    TextField("Password", text: $password)
+                        .textFieldStyle(.roundedBorder)
+                }
+                .padding()
+                Image(systemName: "airplane") // 카카오 연동
+                    .resizable()
+                    .frame(width: 50, height: 50)
+            }
+            .padding(30)
+        }
+    }
+}
+
+struct AfterLoginView: View {
+    @State private var nickname = "투두리"
+    var body: some View {
+        HStack {
+            Image(systemName: "airplane")
+                .frame(width: 100)
+            VStack (alignment: .leading) {
+                Text("닉네임")
+                TextField("", text: $nickname)
+                    .textFieldStyle(.roundedBorder)
+            }
         }
     }
 }
@@ -114,21 +163,6 @@ struct FriendsAlarmRow: View {
             Toggle(isOn: $friendsToggle, label: {
                 Text("친구 알림")
                 Text("친구들이 보내는 알림을 조절할 수 있습니다.")
-            })
-            .disabled(!totalToggle)
-        }
-    }
-}
-
-struct NightAlarmRow: View {
-    @State private var nightToggle = true
-    @Binding var totalToggle: Bool
-    
-    var body: some View {
-        HStack {
-            Toggle(isOn: $nightToggle, label: {
-                Text("야간 알림")
-                Text("야간에 오는 알림을 조절할 수 있습니다.")
             })
             .disabled(!totalToggle)
         }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SettingsView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct SettingsView: View {
     @State private var totalToggle = true
-    @State private var isLogin = false
+    @State private var isLogin = true
+    @State private var nickname = "투두리"
     
     var body: some View {
         NavigationSplitView {
@@ -24,7 +25,11 @@ struct SettingsView: View {
                                 .foregroundStyle(Color.gray)
                         }
                     } else {
-                        ProfileView()
+                        NavigationLink {
+                            ProfileEditView(nickname: $nickname)
+                        } label: {
+                            ProfileView(nickname: $nickname)
+                        }
                     }
                 }
                 
@@ -40,7 +45,7 @@ struct SettingsView: View {
                             .foregroundStyle(Color.gray)
                     } else {
                         NavigationLink {
-                            DetailView()
+                            ThemeView()
                         } label: {
                             Text("커스텀 테마를 골라보세요.")
                         }
@@ -49,17 +54,17 @@ struct SettingsView: View {
                 
                 Section(header: Text("설정")) {
                     NavigationLink {
-                        DetailView()
+                        NoticeView()
                     } label: {
                         Text("공지사항")
                     }
                     NavigationLink {
-                        DetailView()
+                        SettingDetailView()
                     } label: {
                         Text("정보")
                     }
                     NavigationLink {
-                        DetailView()
+                        QnAView()
                     } label: {
                         Text("문의사항")
                     }
@@ -67,12 +72,12 @@ struct SettingsView: View {
                 
                 Section(header: Text("계정 관리")) {
                     NavigationLink {
-                        DetailView()
+                        LogoutView()
                     } label: {
                         Text("로그아웃")
                     }
                     NavigationLink {
-                        DetailView()
+                        WithDrawView()
                     } label: {
                         Text("회원 탈퇴")
                     }
@@ -122,16 +127,39 @@ struct LoginView: View {
 
 // 로그인 이후 뷰
 struct ProfileView: View {
-    @State private var nickname = "투두리"
+    @Binding var nickname: String
     var body: some View {
         HStack {
             Image(systemName: "airplane")
                 .frame(width: 100)
             VStack (alignment: .leading) {
-                Text("닉네임")
-                TextField("", text: $nickname)
-                    .textFieldStyle(.roundedBorder)
+                Text("닉네임: \(nickname)")
+                Text("")
             }
+        }
+        .padding()
+    }
+}
+
+struct ProfileEditView: View {
+    @Binding var nickname: String
+    var body: some View {
+        ZStack {
+            Color(hex: 0xFFFAE1)
+                .ignoresSafeArea()
+            VStack {
+                HStack {
+                    Image(systemName: "airplane")
+                        .frame(width: 100)
+                    VStack (alignment: .leading) {
+                        Text("닉네임")
+                        TextField("닉네임을 설정해주세요.", text: $nickname)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                }
+                
+            }
+            .padding()
         }
     }
 }
@@ -181,6 +209,81 @@ struct FriendsAlarmRow: View {
         }
     }
 }
+
+// 커스텀테마 뷰
+struct ThemeView: View {
+    var body: some View {
+        ZStack {
+            Color(hex: 0xFFFAE1)
+                .ignoresSafeArea()
+            VStack {
+                Text("커스텀 테마 기능 지원 예정")
+                    .foregroundStyle(Color.gray)
+            }
+        }
+    }
+}
+
+struct NoticeView: View {
+    var body: some View {
+        ZStack {
+            Color(hex: 0xFFFAE1)
+                .ignoresSafeArea()
+            VStack {
+                Text("공지 사항 뷰")
+            }
+        }
+    }
+}
+
+struct SettingDetailView: View {
+    var body: some View {
+        ZStack {
+            Color(hex: 0xFFFAE1)
+                .ignoresSafeArea()
+            VStack {
+                Text("어플 정보 뷰")
+            }
+        }
+    }
+}
+
+struct QnAView: View {
+    var body: some View {
+        ZStack {
+            Color(hex: 0xFFFAE1)
+                .ignoresSafeArea()
+            VStack {
+                Text("문의사항 뷰")
+            }
+        }
+    }
+}
+
+struct LogoutView: View {
+    var body: some View {
+        ZStack {
+            Color(hex: 0xFFFAE1)
+                .ignoresSafeArea()
+            VStack {
+                Text("로그아웃 뷰")
+            }
+        }
+    }
+}
+
+struct WithDrawView: View {
+    var body: some View {
+        ZStack {
+            Color(hex: 0xFFFAE1)
+                .ignoresSafeArea()
+            VStack {
+                Text("회원탈퇴 뷰")
+            }
+        }
+    }
+}
+
 
 #Preview {
     SettingsView()


### PR DESCRIPTION
## 이슈번호
🔐 close #41 

## 작업사항
- SettingView 색 통일
- 전체적인 UI 완성
- 로그인, 비로그인 UI 완성
- 프로필 사진, 이름 변경하기

## 향후 작업 예정
- 닉네임, 프로필 사진 CoreData에 저장하기
- 카카오 로그인 API 연동하기
- 프로필 사진, 이름 변경 저장 버튼 만들기

## 스크린샷

- UI 작업이었다면 개발 전과 후 화면을 캡처해서 올려주세요.

<img width="318" alt="스크린샷 2023-12-13 오전 10 54 29" src="https://github.com/APP-iOS3rd/PJ2T12_Again12/assets/42514601/61ed801e-0aa1-42aa-8cf9-02588917ebf2">

<img width="318" alt="스크린샷 2023-12-13 오전 10 55 16" src="https://github.com/APP-iOS3rd/PJ2T12_Again12/assets/42514601/2916e4b6-30de-4062-88ab-7a787e682886">


