### PR TITLE
Feat: Social 뷰 UI 및 친구 dummy data 불러오기 구현

### DIFF
--- a/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
+++ b/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0E36BAA62B26B6BF003EA141 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BAA52B26B6BF003EA141 /* Color.swift */; };
 		0E36BAB22B26F64C003EA141 /* EditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BAB12B26F64C003EA141 /* EditViewModel.swift */; };
 		9E7852B12B28419E003BC698 /* SocialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7852B02B28419E003BC698 /* SocialViewModel.swift */; };
+		9E7852B32B2860D5003BC698 /* SocialDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7852B22B2860D5003BC698 /* SocialDetailView.swift */; };
 		9E9A102B2B26CF6600A2A73E /* HomeModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9A102A2B26CF6600A2A73E /* HomeModalView.swift */; };
 		CEB9F57E2B219941005A338E /* PJ2T12_Again12App.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9F57D2B219941005A338E /* PJ2T12_Again12App.swift */; };
 		CEB9F5822B219944005A338E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEB9F5812B219944005A338E /* Assets.xcassets */; };
@@ -35,6 +36,7 @@
 		0E36BAA52B26B6BF003EA141 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		0E36BAB12B26F64C003EA141 /* EditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewModel.swift; sourceTree = "<group>"; };
 		9E7852B02B28419E003BC698 /* SocialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialViewModel.swift; sourceTree = "<group>"; };
+		9E7852B22B2860D5003BC698 /* SocialDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialDetailView.swift; sourceTree = "<group>"; };
 		9E9A102A2B26CF6600A2A73E /* HomeModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModalView.swift; sourceTree = "<group>"; };
 		CEB9F57A2B219941005A338E /* PJ2T12_Again12.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PJ2T12_Again12.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEB9F57D2B219941005A338E /* PJ2T12_Again12App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PJ2T12_Again12App.swift; sourceTree = "<group>"; };
@@ -128,6 +130,7 @@
 				9E9A102A2B26CF6600A2A73E /* HomeModalView.swift */,
 				CEB9F59C2B21A9CE005A338E /* SettingsView.swift */,
 				CEB9F59A2B21A9C5005A338E /* SocialView.swift */,
+				9E7852B22B2860D5003BC698 /* SocialDetailView.swift */,
 				CEB9F5962B21A966005A338E /* StatusView.swift */,
 				CEB9F5902B21A925005A338E /* TodoriTapView.swift */,
 			);
@@ -218,6 +221,7 @@
 				CEB9F5992B21A9A9005A338E /* HistoryView.swift in Sources */,
 				CEB9F5952B21A950005A338E /* DetailView.swift in Sources */,
 				CEB9F57E2B219941005A338E /* PJ2T12_Again12App.swift in Sources */,
+				9E7852B32B2860D5003BC698 /* SocialDetailView.swift in Sources */,
 				CEB9F58F2B219A85005A338E /* User.swift in Sources */,
 				E3456BB02B26FD2100EEA7B1 /* String.swift in Sources */,
 				0E36BAA62B26B6BF003EA141 /* Color.swift in Sources */,

--- a/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
+++ b/PJ2T12_Again12/PJ2T12_Again12.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0E36BAA32B26B696003EA141 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BAA22B26B696003EA141 /* HomeViewModel.swift */; };
 		0E36BAA62B26B6BF003EA141 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BAA52B26B6BF003EA141 /* Color.swift */; };
 		0E36BAB22B26F64C003EA141 /* EditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36BAB12B26F64C003EA141 /* EditViewModel.swift */; };
+		9E7852B12B28419E003BC698 /* SocialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7852B02B28419E003BC698 /* SocialViewModel.swift */; };
 		9E9A102B2B26CF6600A2A73E /* HomeModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9A102A2B26CF6600A2A73E /* HomeModalView.swift */; };
 		CEB9F57E2B219941005A338E /* PJ2T12_Again12App.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9F57D2B219941005A338E /* PJ2T12_Again12App.swift */; };
 		CEB9F5822B219944005A338E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEB9F5812B219944005A338E /* Assets.xcassets */; };
@@ -33,6 +34,7 @@
 		0E36BAA22B26B696003EA141 /* HomeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		0E36BAA52B26B6BF003EA141 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		0E36BAB12B26F64C003EA141 /* EditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewModel.swift; sourceTree = "<group>"; };
+		9E7852B02B28419E003BC698 /* SocialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialViewModel.swift; sourceTree = "<group>"; };
 		9E9A102A2B26CF6600A2A73E /* HomeModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModalView.swift; sourceTree = "<group>"; };
 		CEB9F57A2B219941005A338E /* PJ2T12_Again12.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PJ2T12_Again12.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEB9F57D2B219941005A338E /* PJ2T12_Again12App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PJ2T12_Again12App.swift; sourceTree = "<group>"; };
@@ -137,6 +139,7 @@
 			children = (
 				0E36BAA22B26B696003EA141 /* HomeViewModel.swift */,
 				0E36BAB12B26F64C003EA141 /* EditViewModel.swift */,
+				9E7852B02B28419E003BC698 /* SocialViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -218,6 +221,7 @@
 				CEB9F58F2B219A85005A338E /* User.swift in Sources */,
 				E3456BB02B26FD2100EEA7B1 /* String.swift in Sources */,
 				0E36BAA62B26B6BF003EA141 /* Color.swift in Sources */,
+				9E7852B12B28419E003BC698 /* SocialViewModel.swift in Sources */,
 				CEB9F59D2B21A9CE005A338E /* SettingsView.swift in Sources */,
 				CEB9F59B2B21A9C5005A338E /* SocialView.swift in Sources */,
 				0E36BA7E2B22F41E003EA141 /* EditView.swift in Sources */,

--- a/PJ2T12_Again12/PJ2T12_Again12/Models/User.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Models/User.swift
@@ -40,7 +40,7 @@ struct WantTodo: Identifiable {
     var status: Bool
 }
 
-struct Medal {
+struct Medal: Hashable {
     var title: String
     var image: String
     var status: Bool

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -12,6 +12,13 @@ class SocialViewModel: ObservableObject {
     @Published var isLogin = true
     @Published var myFriendsList: [User] = [SampleUsers().userOne, SampleUsers().userTwo, SampleUsers().userThree]
     
+    func setDateFormat(_ date: Date) -> String {
+        let year = date.formatted(Date.FormatStyle().year(.defaultDigits))
+        let month = date.formatted(Date.FormatStyle().month(.twoDigits))
+        
+        return "\(year)-\(month)"
+    }
+    
     func countDone(_ user: User) -> Int {
         let totalTodo = user.todoByMonthList.last?.todoList ?? user.todoByMonthList[0].todoList
         let totalWantTodo = user.todoByMonthList.last?.wantTodoList ?? user.todoByMonthList[0].wantTodoList

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  SocialViewModel.swift
+//  PJ2T12_Again12
+//
+//  Created by Eunsu JEONG on 12/12/23.
+//
+
+import SwiftUI
+
+@MainActor
+class SocialViewModel: ObservableObject {
+    @Published var isLogin = false
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -13,8 +13,8 @@ class SocialViewModel: ObservableObject {
     @Published var myFriendsList: [User] = [SampleUsers().userOne, SampleUsers().userTwo, SampleUsers().userThree]
     
     func countDone(_ user: User) -> Int {
-        let totalTodo = user.todoByMonthList[0].todoList
-        let totalWantTodo = user.todoByMonthList[0].wantTodoList
+        let totalTodo = user.todoByMonthList.last?.todoList ?? user.todoByMonthList[0].todoList
+        let totalWantTodo = user.todoByMonthList.last?.wantTodoList ?? user.todoByMonthList[0].wantTodoList
         var count = 0
         
         for todo in totalTodo {

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -20,19 +20,24 @@ class SocialViewModel: ObservableObject {
     }
     
     func countDone(_ user: User) -> Int {
-        let totalTodo = user.todoByMonthList.last?.todoList ?? user.todoByMonthList[0].todoList
-        let totalWantTodo = user.todoByMonthList.last?.wantTodoList ?? user.todoByMonthList[0].wantTodoList
         var count = 0
         
-        for todo in totalTodo {
-            if todo.status {
-                count += 1
-            }
-        }
-        
-        for wantTodo in totalWantTodo {
-            if wantTodo.status {
-                count += 1
+        if let recentTodoDate = user.todoByMonthList.last?.date {
+            if setDateFormat(recentTodoDate) == setDateFormat(Date.now) {
+                let totalTodo = user.todoByMonthList.last?.todoList ?? []
+                let totalWantTodo = user.todoByMonthList.last?.wantTodoList ?? []
+                
+                for todo in totalTodo {
+                    if todo.status {
+                        count += 1
+                    }
+                }
+                
+                for wantTodo in totalWantTodo {
+                    if wantTodo.status {
+                        count += 1
+                    }
+                }
             }
         }
         

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -9,5 +9,64 @@ import SwiftUI
 
 @MainActor
 class SocialViewModel: ObservableObject {
-    @Published var isLogin = false
+    @Published var isLogin = true
+}
+
+@MainActor
+class myFriend: ObservableObject {
+    @Published var myFriendsList: [User] = [SampleUsers().userOne, SampleUsers().userTwo, SampleUsers().userThree]
+}
+
+struct SampleTodo {
+    var toDoOne = Todo(date: Date.now, title: "일찍일어나기", image: "airplane", review: "했다", status: true)
+    var toDoTwo = Todo(date: Date.now, title: "크리스마스 쿠키 만들기", review: "", status: false)
+    var toDoThree = Todo(date: Date.now, title: "열심히 공부하기", review: "", status: false)
+}
+
+struct SampleWantTodo {
+    var wantTodoOne = WantTodo(date: Date.now, title: "네트워크 공부", review: "", status: false)
+    var wantTodoTow = WantTodo(date: Date.now, title: "수업 복습", image: "airplane", review: "무진장 많았는데 결국 난 해냈다", status: true)
+    var wantTodoThree = WantTodo(date: Date.now, title: "수영하기", image: "airplane", review: "드디어 신청", status: true)
+}
+
+struct SampleMedal {
+    var medalOne = Medal(title: "일 년 달성", image: "star", status: false, count: 0)
+    var medalTwo = Medal(title: "한 달 달성", image: "star.fill", status: true, count: 0)
+    var medalThree = Medal(title: "하고 싶은 투두 10개 달성", image: "moon.fill", status: true, count: 0)
+    var medalFour = Medal(title: "해야 하는 투두 10개 달성", image: "moon", status: false, count: 0)
+}
+
+struct SampleUsers {
+    var userOne: User = User(
+        name: "친구1",
+        profileImage: "cat",
+        todoByMonthList: [TodoByMonth(date: Date.now,
+                                      todoList: [SampleTodo().toDoOne, SampleTodo().toDoThree],
+                                      wantTodoList: [SampleWantTodo().wantTodoOne]
+                                     )],
+        friendList: nil,
+        medalList: [SampleMedal().medalOne, SampleMedal().medalTwo]
+    )
+    
+    var userTwo: User = User(
+        name: "친구2",
+        profileImage: "lizard",
+        todoByMonthList: [TodoByMonth(date: Date.now,
+                                      todoList: [SampleTodo().toDoOne, SampleTodo().toDoTwo],
+                                      wantTodoList: [SampleWantTodo().wantTodoOne, SampleWantTodo().wantTodoThree]
+                                     )],
+        friendList: nil,
+        medalList: [SampleMedal().medalOne, SampleMedal().medalFour]
+    )
+    
+    var userThree: User = User(
+        name: "친구3",
+        profileImage: "tortoise",
+        todoByMonthList: [TodoByMonth(date: Date.now,
+                                      todoList: [SampleTodo().toDoOne, SampleTodo().toDoTwo, SampleTodo().toDoThree],
+                                      wantTodoList: [SampleWantTodo().wantTodoThree, SampleWantTodo().wantTodoTow]
+                                     )],
+        friendList: nil,
+        medalList: [SampleMedal().medalTwo, SampleMedal().medalFour, SampleMedal().medalThree]
+    )
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @MainActor
 class SocialViewModel: ObservableObject {
-    @Published var isLogin = true
+    @Published var isLogin = false
     @Published var myFriendsList: [User] = [SampleUsers().userOne, SampleUsers().userTwo, SampleUsers().userThree, SampleUsers().userFour]
     
     func setDateFormat(_ date: Date) -> String {

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -38,6 +38,18 @@ class SocialViewModel: ObservableObject {
         
         return count
     }
+    
+    func countTotal(_ user: User) -> Int {
+        var totalCount = 0
+        
+        if let recentTodoDate = user.todoByMonthList.last?.date {
+            if setDateFormat(recentTodoDate) == setDateFormat(Date.now) {
+                totalCount = (user.todoByMonthList.last?.todoList.count ?? 0) + (user.todoByMonthList.last?.wantTodoList.count ?? 0)
+            }
+        }
+        
+        return totalCount
+    }
 }
 
 struct SampleTodo {

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -10,10 +10,6 @@ import SwiftUI
 @MainActor
 class SocialViewModel: ObservableObject {
     @Published var isLogin = true
-}
-
-@MainActor
-class myFriend: ObservableObject {
     @Published var myFriendsList: [User] = [SampleUsers().userOne, SampleUsers().userTwo, SampleUsers().userThree]
 }
 

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @MainActor
 class SocialViewModel: ObservableObject {
     @Published var isLogin = true
-    @Published var myFriendsList: [User] = [SampleUsers().userOne, SampleUsers().userTwo, SampleUsers().userThree]
+    @Published var myFriendsList: [User] = [SampleUsers().userOne, SampleUsers().userTwo, SampleUsers().userThree, SampleUsers().userFour]
     
     func setDateFormat(_ date: Date) -> String {
         let year = date.formatted(Date.FormatStyle().year(.defaultDigits))
@@ -108,5 +108,16 @@ struct SampleUsers {
                                      )],
         friendList: nil,
         medalList: [SampleMedal().medalTwo, SampleMedal().medalFour, SampleMedal().medalThree]
+    )
+    
+    var userFour: User = User(
+        name: "친구4",
+        profileImage: "cat",
+        todoByMonthList: [TodoByMonth(date: Calendar.current.date(from: DateComponents(year: 2023, month: 08, day: 30))!,
+                                      todoList: [SampleTodo().toDoOne, SampleTodo().toDoThree],
+                                      wantTodoList: [SampleWantTodo().wantTodoOne]
+                                     )],
+        friendList: nil,
+        medalList: [SampleMedal().medalOne, SampleMedal().medalTwo]
     )
 }

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -87,22 +87,22 @@ class SocialViewModel: ObservableObject {
 }
 
 struct SampleTodo {
-    var toDoOne = Todo(date: Date.now, title: "일찍일어나기", image: "airplane", review: "했다", status: true)
-    var toDoTwo = Todo(date: Date.now, title: "크리스마스 쿠키 만들기", review: "", status: false)
-    var toDoThree = Todo(date: Date.now, title: "열심히 공부하기", review: "", status: false)
+    var toDoOne = Todo(date: Date.now, title: "일찍일어나기", image: "dumbbell", review: "했다", status: true)
+    var toDoTwo = Todo(date: Date.now, title: "크리스마스 쿠키 만들기", image: "paperplane", review: "", status: false)
+    var toDoThree = Todo(date: Date.now, title: "열심히 공부하기", image:"book.closed", review: "", status: false)
 }
 
 struct SampleWantTodo {
-    var wantTodoOne = WantTodo(date: Date.now, title: "네트워크 공부", review: "", status: false)
-    var wantTodoTow = WantTodo(date: Date.now, title: "수업 복습", image: "airplane", review: "무진장 많았는데 결국 난 해냈다", status: true)
-    var wantTodoThree = WantTodo(date: Date.now, title: "수영하기", image: "airplane", review: "드디어 신청", status: true)
+    var wantTodoOne = WantTodo(date: Date.now, title: "네트워크 공부", image: "paperplane", review: "", status: false)
+    var wantTodoTow = WantTodo(date: Date.now, title: "수업 복습", image: "paperplane", review: "무진장 많았는데 결국 난 해냈다", status: true)
+    var wantTodoThree = WantTodo(date: Date.now, title: "수영하기", image: "dumbbell", review: "드디어 신청", status: true)
 }
 
 struct SampleMedal {
     var medalOne = Medal(title: "일 년 달성", image: "star", status: false, count: 0)
     var medalTwo = Medal(title: "한 달 달성", image: "star.fill", status: true, count: 0)
-    var medalThree = Medal(title: "하고 싶은 투두 10개 달성", image: "moon.fill", status: true, count: 0)
-    var medalFour = Medal(title: "해야 하는 투두 10개 달성", image: "moon", status: false, count: 0)
+    var medalThree = Medal(title: "하고 싶은 투두 10개 달성", image: "moon.stars.fill", status: true, count: 0)
+    var medalFour = Medal(title: "해야 하는 투두 10개 달성", image: "moon.stars", status: false, count: 0)
 }
 
 struct SampleUsers {

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -11,6 +11,26 @@ import SwiftUI
 class SocialViewModel: ObservableObject {
     @Published var isLogin = true
     @Published var myFriendsList: [User] = [SampleUsers().userOne, SampleUsers().userTwo, SampleUsers().userThree]
+    
+    func countDone(_ user: User) -> Int {
+        let totalTodo = user.todoByMonthList[0].todoList
+        let totalWantTodo = user.todoByMonthList[0].wantTodoList
+        var count = 0
+        
+        for todo in totalTodo {
+            if todo.status {
+                count += 1
+            }
+        }
+        
+        for wantTodo in totalWantTodo {
+            if wantTodo.status {
+                count += 1
+            }
+        }
+        
+        return count
+    }
 }
 
 struct SampleTodo {

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -16,7 +16,7 @@ class SocialViewModel: ObservableObject {
         let year = date.formatted(Date.FormatStyle().year(.defaultDigits))
         let month = date.formatted(Date.FormatStyle().month(.twoDigits))
         
-        return "\(year)-\(month)"
+        return "\(year).\(month)"
     }
     
     ///어떤 유저의 가장 최신의 TodoByMonth 데이터가 이번 달인지 판별한다.

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -112,7 +112,7 @@ struct SampleUsers {
     
     var userFour: User = User(
         name: "친구4",
-        profileImage: "cat",
+        profileImage: "teddybear",
         todoByMonthList: [TodoByMonth(date: Calendar.current.date(from: DateComponents(year: 2023, month: 08, day: 30))!,
                                       todoList: [SampleTodo().toDoOne, SampleTodo().toDoThree],
                                       wantTodoList: [SampleWantTodo().wantTodoOne]

--- a/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/ViewModels/SocialViewModel.swift
@@ -19,24 +19,55 @@ class SocialViewModel: ObservableObject {
         return "\(year)-\(month)"
     }
     
-    func countDone(_ user: User) -> Int {
-        var count = 0
+    ///어떤 유저의 가장 최신의 TodoByMonth 데이터가 이번 달인지 판별한다.
+    func isThisMonth(_ user: User) -> Bool {
+        var isThisMonth = false
         
         if let recentTodoDate = user.todoByMonthList.last?.date {
             if setDateFormat(recentTodoDate) == setDateFormat(Date.now) {
-                let totalTodo = user.todoByMonthList.last?.todoList ?? []
-                let totalWantTodo = user.todoByMonthList.last?.wantTodoList ?? []
-                
-                for todo in totalTodo {
-                    if todo.status {
-                        count += 1
-                    }
+                isThisMonth = true
+            }}
+        return isThisMonth
+    }
+    
+    ///어떤 유저가 TodoByMonth 데이터가 있다면 가장 최신 데이터인 todoList를 가지고 온다.
+    func getTodoList(_ user: User) -> [Todo] {
+        var result: [Todo] = []
+        
+        if let todoList = user.todoByMonthList.last?.todoList {
+            result = todoList
+        }
+        
+        return result
+    }
+    
+    ///어떤 유저가 TodoByMonth 데이터가 있다면 가장 최신 데이터인 wantTodoList를 가지고 온다.
+    func getWantTodoList(_ user: User) -> [WantTodo] {
+        var result: [WantTodo] = []
+        
+        if let wantTodoList = user.todoByMonthList.last?.wantTodoList {
+            result = wantTodoList
+        }
+        
+        return result
+    }
+    
+    func countDone(_ user: User) -> Int {
+        var count = 0
+        
+        if isThisMonth(user) {
+            let totalTodo = getTodoList(user)
+            let totalWantTodo = getWantTodoList(user)
+            
+            for todo in totalTodo {
+                if todo.status {
+                    count += 1
                 }
-                
-                for wantTodo in totalWantTodo {
-                    if wantTodo.status {
-                        count += 1
-                    }
+            }
+            
+            for wantTodo in totalWantTodo {
+                if wantTodo.status {
+                    count += 1
                 }
             }
         }
@@ -47,10 +78,8 @@ class SocialViewModel: ObservableObject {
     func countTotal(_ user: User) -> Int {
         var totalCount = 0
         
-        if let recentTodoDate = user.todoByMonthList.last?.date {
-            if setDateFormat(recentTodoDate) == setDateFormat(Date.now) {
-                totalCount = (user.todoByMonthList.last?.todoList.count ?? 0) + (user.todoByMonthList.last?.wantTodoList.count ?? 0)
-            }
+        if isThisMonth(user) {
+            totalCount = getTodoList(user).count + getWantTodoList(user).count
         }
         
         return totalCount

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SocialDetailView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SocialDetailView.swift
@@ -25,105 +25,106 @@ struct SocialDetailView: View {
         ZStack {
             viewbackgroundColor
                 .ignoresSafeArea()
-            ScrollView {
+            VStack {
                 //Title: 이번 달
                 HStack {
                     Text("\(socialVM.setDateFormat(Date.now))")
                         .foregroundStyle(todoriBlack)
                         .font(.system(titleFontSize, weight: titleFontWeight))
-
+                    
                     Spacer()
                 } //HStack
                 .padding(.bottom, 4)
-                
-                // 하고싶은일 + 해야하는일 + 뱃지
-                VStack(spacing: 16) {
-                    // 하고 싶은 일
-                    VStack {
-                        HStack {
-                            Text("하고 싶으면")
-                                .bold()
-                            
-                            Spacer()
-                        } //HStack
-                        
+                ScrollView {
+                    // 하고싶은일 + 해야하는일 + 뱃지
+                    VStack(spacing: 16) {
+                        // 하고 싶은 일
                         VStack {
-                            if socialVM.isThisMonth(friend) {
-                                let todoList: [Todo] = socialVM.getTodoList(friend)
-                                ForEach(todoList) { todo in
-                                    Text(todo.title)
-                                        .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
-                                }
-                            }
-                        } //VStack
-                        .padding()
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(todoListGroupBorderColor.opacity(0.32), 
-                                        lineWidth: 2)
-                        )
-                    } //VStack
-                    
-                    // 해야 하는 일
-                    VStack {
-                        HStack {
-                            Text("해야 하면")
-                                .bold()
-                            Spacer()
-                        } //HStack
-                        
-                        VStack {
-                            if socialVM.isThisMonth(friend) {
-                                let wantTodoList: [WantTodo] = socialVM.getWantTodoList(friend)
-                                ForEach(wantTodoList) { wantTodo in
-                                    Text(wantTodo.title)
-                                        .modifier(TodoCellModifier(status: wantTodo.status, hexCode: 0xB76300))
-                                }
-                            }
-                        } //VStack
-                        .padding()
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(todoListGroupBorderColor.opacity(0.32), 
-                                        lineWidth: 2)
-                        )
-                    } //VStack
-                    
-                    //뱃지: Model의 Medal이 Hashable해야지만 작동
-                    VStack {
-                        HStack {
-                            Text("뱃지")
-                                .bold()
-                            
-                            Spacer()
-                        } //HStack
-                        
-                        VStack {
-                            LazyVGrid(columns: Array(repeating: GridItem(.adaptive(minimum: 90)), count: 3)) {
-                                let medalsList: [Medal] = friend.medalList
+                            HStack {
+                                Text("하고 싶으면")
+                                    .bold()
                                 
-                                ForEach(medalsList, id: \.self) { medal in
-                                    ZStack {
-                                        RoundedRectangle(cornerRadius: 10)
-                                            .frame(width: 90, height: 100)
-                                            .foregroundStyle(medalBackgroundColor)
-                                        
-                                        Image(systemName: medal.image)
-                                            .font(.system(size: 40))
+                                Spacer()
+                            } //HStack
+                            
+                            VStack {
+                                if socialVM.isThisMonth(friend) {
+                                    let todoList: [Todo] = socialVM.getTodoList(friend)
+                                    ForEach(todoList) { todo in
+                                        Text(todo.title)
+                                            .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
                                     }
                                 }
-                            } //LazyVGrid
+                            } //VStack
+                            .padding()
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(todoListGroupBorderColor.opacity(0.32),
+                                            lineWidth: 2)
+                            )
                         } //VStack
-                        .frame(width: 330)
-                        .padding()
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(todoListGroupBorderColor.opacity(0.32),
-                                        lineWidth: 2)
-                        )
+                        
+                        // 해야 하는 일
+                        VStack {
+                            HStack {
+                                Text("해야 하면")
+                                    .bold()
+                                Spacer()
+                            } //HStack
+                            
+                            VStack {
+                                if socialVM.isThisMonth(friend) {
+                                    let wantTodoList: [WantTodo] = socialVM.getWantTodoList(friend)
+                                    ForEach(wantTodoList) { wantTodo in
+                                        Text(wantTodo.title)
+                                            .modifier(TodoCellModifier(status: wantTodo.status, hexCode: 0xB76300))
+                                    }
+                                }
+                            } //VStack
+                            .padding()
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(todoListGroupBorderColor.opacity(0.32),
+                                            lineWidth: 2)
+                            )
+                        } //VStack
+                        
+                        //뱃지: Model의 Medal이 Hashable해야지만 작동
+                        VStack {
+                            HStack {
+                                Text("뱃지")
+                                    .bold()
+                                
+                                Spacer()
+                            } //HStack
+                            
+                            VStack {
+                                LazyVGrid(columns: Array(repeating: GridItem(.adaptive(minimum: 90)), count: 3)) {
+                                    let medalsList: [Medal] = friend.medalList
+                                    
+                                    ForEach(medalsList, id: \.self) { medal in
+                                        ZStack {
+                                            RoundedRectangle(cornerRadius: 10)
+                                                .frame(width: 90, height: 100)
+                                                .foregroundStyle(medalBackgroundColor)
+                                            
+                                            Image(systemName: medal.image)
+                                                .font(.system(size: 40))
+                                        }
+                                    }
+                                } //LazyVGrid
+                            } //VStack
+                            .frame(width: 330)
+                            .padding()
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(todoListGroupBorderColor.opacity(0.32),
+                                            lineWidth: 2)
+                            )
+                        } //VStack
                     } //VStack
-                } //VStack
-            } //ScrollView
+                } //ScrollView
+            } //VStack
             .padding()
         } //ZStack
     }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SocialDetailView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SocialDetailView.swift
@@ -1,0 +1,134 @@
+//
+//  SocialDetailView.swift
+//  PJ2T12_Again12
+//
+//  Created by Eunsu JEONG on 12/12/23.
+//
+
+import SwiftUI
+
+struct SocialDetailView: View {
+    @ObservedObject var socialVM: SocialViewModel
+    @State var friend: User
+    
+    //Font
+    let titleFontSize: Font.TextStyle = .largeTitle
+    let titleFontWeight: Font.Weight = .medium
+    
+    //Color
+    let viewbackgroundColor: Color = Color(hex: 0xFFFAE1)
+    let todoriBlack: Color = Color(hex: 0x432D00)
+    let todoListGroupBorderColor: Color = Color(hex: 0xA58B00)
+    let medalBackgroundColor: Color = .white
+    
+    var body: some View {
+        ZStack {
+            viewbackgroundColor
+                .ignoresSafeArea()
+            ScrollView {
+                //Title: 이번 달
+                HStack {
+                    Text("\(socialVM.setDateFormat(Date.now))")
+                        .foregroundStyle(todoriBlack)
+                        .font(.system(titleFontSize, weight: titleFontWeight))
+
+                    Spacer()
+                } //HStack
+                .padding(.bottom, 4)
+                
+                // 하고싶은일 + 해야하는일 + 뱃지
+                VStack(spacing: 16) {
+                    // 하고 싶은 일
+                    VStack {
+                        HStack {
+                            Text("하고 싶으면")
+                                .bold()
+                            
+                            Spacer()
+                        } //HStack
+                        
+                        VStack {
+                            if socialVM.isThisMonth(friend) {
+                                let todoList: [Todo] = socialVM.getTodoList(friend)
+                                ForEach(todoList) { todo in
+                                    Text(todo.title)
+                                        .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
+                                }
+                            }
+                        } //VStack
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(todoListGroupBorderColor.opacity(0.32), 
+                                        lineWidth: 2)
+                        )
+                    } //VStack
+                    
+                    // 해야 하는 일
+                    VStack {
+                        HStack {
+                            Text("해야 하면")
+                                .bold()
+                            Spacer()
+                        } //HStack
+                        
+                        VStack {
+                            if socialVM.isThisMonth(friend) {
+                                let wantTodoList: [WantTodo] = socialVM.getWantTodoList(friend)
+                                ForEach(wantTodoList) { wantTodo in
+                                    Text(wantTodo.title)
+                                        .modifier(TodoCellModifier(status: wantTodo.status, hexCode: 0xB76300))
+                                }
+                            }
+                        } //VStack
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(todoListGroupBorderColor.opacity(0.32), 
+                                        lineWidth: 2)
+                        )
+                    } //VStack
+                    
+                    //뱃지: Model의 Medal이 Hashable해야지만 작동
+                    VStack {
+                        HStack {
+                            Text("뱃지")
+                                .bold()
+                            
+                            Spacer()
+                        } //HStack
+                        
+                        VStack {
+                            LazyVGrid(columns: Array(repeating: GridItem(.adaptive(minimum: 90)), count: 3)) {
+                                let medalsList: [Medal] = friend.medalList
+                                
+                                ForEach(medalsList, id: \.self) { medal in
+                                    ZStack {
+                                        RoundedRectangle(cornerRadius: 10)
+                                            .frame(width: 90, height: 100)
+                                            .foregroundStyle(medalBackgroundColor)
+                                        
+                                        Image(systemName: medal.image)
+                                            .font(.system(size: 40))
+                                    }
+                                }
+                            } //LazyVGrid
+                        } //VStack
+                        .frame(width: 330)
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(todoListGroupBorderColor.opacity(0.32),
+                                        lineWidth: 2)
+                        )
+                    } //VStack
+                } //VStack
+            } //ScrollView
+            .padding()
+        } //ZStack
+    }
+}
+
+#Preview {
+    SocialDetailView(socialVM: SocialViewModel(), friend: SocialViewModel().myFriendsList[2])
+}

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SocialDetailView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SocialDetailView.swift
@@ -14,6 +14,9 @@ struct SocialDetailView: View {
     // Sizes
     let circleSize: CGFloat = 94
     let profileIconSize: CGFloat = 40
+    let buttonWidth: CGFloat = 140
+    let buttonHeight: CGFloat = 52
+    let buttonSpace: CGFloat = 26
     
     //Fonts
     let titleFontSize: Font.TextStyle = .largeTitle
@@ -23,6 +26,8 @@ struct SocialDetailView: View {
     let viewbackgroundColor: Color = Color(hex: 0xFFFAE1)
     let todoriBlack: Color = Color(hex: 0x432D00)
     let profileBackgroundColor: Color = .white
+    let cheerButtonColor: Color = Color(hex: 0xB79800)
+    let hurryButtonColor: Color = Color(hex: 0xB76300)
     let todoListGroupBorderColor: Color = Color(hex: 0xA58B00)
     let medalBackgroundColor: Color = .white
     
@@ -31,7 +36,7 @@ struct SocialDetailView: View {
             viewbackgroundColor
                 .ignoresSafeArea()
             ScrollView {
-                //Title: 이번 달
+                //친구 프로필 이미지와 닉네임
                 HStack {
                     ZStack {
                         Circle()
@@ -42,13 +47,38 @@ struct SocialDetailView: View {
                         
                         Image(systemName: friend.profileImage ?? "person")
                             .font(.system(size: profileIconSize))
-                    }
+                    } //ZStack
                     .padding(.trailing, 30)
                     
                     Text(friend.name ?? "No Name")
                         .foregroundStyle(todoriBlack)
                         .font(.system(titleFontSize, weight: titleFontWeight))
                 } //HStack
+                .padding(.bottom, 20)
+                
+                //응원, 재촉 버튼
+                HStack {
+                    Button {
+                        //기능구현안됨
+                    } label: {
+                        Text("🎉 응원하기")
+                            .frame(width: buttonWidth, height: buttonHeight)
+                            .foregroundStyle(todoriBlack)
+                            .background(cheerButtonColor)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                    }
+                    .padding(.trailing, buttonSpace)
+                    
+                    Button {
+                        //기능구현안됨
+                    } label: {
+                        Text("🚨 재촉하기")
+                            .frame(width: buttonWidth, height: buttonHeight)
+                            .foregroundStyle(todoriBlack)
+                            .background(hurryButtonColor)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                    }
+                }
                 .padding(.bottom, 20)
                 
                 // 하고싶은일 + 해야하는일 + 뱃지

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SocialDetailView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SocialDetailView.swift
@@ -11,13 +11,18 @@ struct SocialDetailView: View {
     @ObservedObject var socialVM: SocialViewModel
     @State var friend: User
     
-    //Font
+    // Sizes
+    let circleSize: CGFloat = 94
+    let profileIconSize: CGFloat = 40
+    
+    //Fonts
     let titleFontSize: Font.TextStyle = .largeTitle
     let titleFontWeight: Font.Weight = .medium
     
-    //Color
+    //Colors
     let viewbackgroundColor: Color = Color(hex: 0xFFFAE1)
     let todoriBlack: Color = Color(hex: 0x432D00)
+    let profileBackgroundColor: Color = .white
     let todoListGroupBorderColor: Color = Color(hex: 0xA58B00)
     let medalBackgroundColor: Color = .white
     
@@ -25,106 +30,115 @@ struct SocialDetailView: View {
         ZStack {
             viewbackgroundColor
                 .ignoresSafeArea()
-            VStack {
+            ScrollView {
                 //Title: 이번 달
                 HStack {
-                    Text("\(socialVM.setDateFormat(Date.now))")
+                    ZStack {
+                        Circle()
+                            .stroke(todoriBlack, lineWidth: 1.0)
+                            .frame(width: circleSize, height: circleSize)
+                            .background(profileBackgroundColor)
+                            .clipShape(Circle())
+                        
+                        Image(systemName: friend.profileImage ?? "person")
+                            .font(.system(size: profileIconSize))
+                    }
+                    .padding(.trailing, 30)
+                    
+                    Text(friend.name ?? "No Name")
                         .foregroundStyle(todoriBlack)
                         .font(.system(titleFontSize, weight: titleFontWeight))
-                    
-                    Spacer()
                 } //HStack
-                .padding(.bottom, 4)
-                ScrollView {
-                    // 하고싶은일 + 해야하는일 + 뱃지
-                    VStack(spacing: 16) {
-                        // 하고 싶은 일
-                        VStack {
-                            HStack {
-                                Text("하고 싶으면")
-                                    .bold()
-                                
-                                Spacer()
-                            } //HStack
+                .padding(.bottom, 20)
+                
+                // 하고싶은일 + 해야하는일 + 뱃지
+                VStack(spacing: 16) {
+                    // 하고 싶은 일
+                    VStack {
+                        HStack {
+                            Text("하고 싶으면")
+                                .bold()
                             
-                            VStack {
-                                if socialVM.isThisMonth(friend) {
-                                    let todoList: [Todo] = socialVM.getTodoList(friend)
-                                    ForEach(todoList) { todo in
-                                        Text(todo.title)
-                                            .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
-                                    }
-                                }
-                            } //VStack
-                            .padding()
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(todoListGroupBorderColor.opacity(0.32),
-                                            lineWidth: 2)
-                            )
-                        } //VStack
+                            Spacer()
+                        } //HStack
                         
-                        // 해야 하는 일
                         VStack {
-                            HStack {
-                                Text("해야 하면")
-                                    .bold()
-                                Spacer()
-                            } //HStack
-                            
-                            VStack {
-                                if socialVM.isThisMonth(friend) {
-                                    let wantTodoList: [WantTodo] = socialVM.getWantTodoList(friend)
-                                    ForEach(wantTodoList) { wantTodo in
-                                        Text(wantTodo.title)
-                                            .modifier(TodoCellModifier(status: wantTodo.status, hexCode: 0xB76300))
-                                    }
+                            if socialVM.isThisMonth(friend) {
+                                let todoList: [Todo] = socialVM.getTodoList(friend)
+                                ForEach(todoList) { todo in
+                                    Text(todo.title)
+                                        .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
                                 }
-                            } //VStack
-                            .padding()
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(todoListGroupBorderColor.opacity(0.32),
-                                            lineWidth: 2)
-                            )
+                            }
                         } //VStack
-                        
-                        //뱃지: Model의 Medal이 Hashable해야지만 작동
-                        VStack {
-                            HStack {
-                                Text("뱃지")
-                                    .bold()
-                                
-                                Spacer()
-                            } //HStack
-                            
-                            VStack {
-                                LazyVGrid(columns: Array(repeating: GridItem(.adaptive(minimum: 90)), count: 3)) {
-                                    let medalsList: [Medal] = friend.medalList
-                                    
-                                    ForEach(medalsList, id: \.self) { medal in
-                                        ZStack {
-                                            RoundedRectangle(cornerRadius: 10)
-                                                .frame(width: 90, height: 100)
-                                                .foregroundStyle(medalBackgroundColor)
-                                            
-                                            Image(systemName: medal.image)
-                                                .font(.system(size: 40))
-                                        }
-                                    }
-                                } //LazyVGrid
-                            } //VStack
-                            .frame(width: 330)
-                            .padding()
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(todoListGroupBorderColor.opacity(0.32),
-                                            lineWidth: 2)
-                            )
-                        } //VStack
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(todoListGroupBorderColor.opacity(0.32), 
+                                        lineWidth: 2)
+                        )
                     } //VStack
-                } //ScrollView
-            } //VStack
+                    
+                    // 해야 하는 일
+                    VStack {
+                        HStack {
+                            Text("해야 하면")
+                                .bold()
+                            Spacer()
+                        } //HStack
+                        
+                        VStack {
+                            if socialVM.isThisMonth(friend) {
+                                let wantTodoList: [WantTodo] = socialVM.getWantTodoList(friend)
+                                ForEach(wantTodoList) { wantTodo in
+                                    Text(wantTodo.title)
+                                        .modifier(TodoCellModifier(status: wantTodo.status, hexCode: 0xB76300))
+                                }
+                            }
+                        } //VStack
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(todoListGroupBorderColor.opacity(0.32), 
+                                        lineWidth: 2)
+                        )
+                    } //VStack
+                    
+                    //뱃지: Model의 Medal이 Hashable해야지만 작동
+                    VStack {
+                        HStack {
+                            Text("뱃지")
+                                .bold()
+                            
+                            Spacer()
+                        } //HStack
+                        
+                        VStack {
+                            LazyVGrid(columns: Array(repeating: GridItem(.adaptive(minimum: 90)), count: 3)) {
+                                let medalsList: [Medal] = friend.medalList
+                                
+                                ForEach(medalsList, id: \.self) { medal in
+                                    ZStack {
+                                        RoundedRectangle(cornerRadius: 10)
+                                            .frame(width: 90, height: 100)
+                                            .foregroundStyle(medalBackgroundColor)
+                                        
+                                        Image(systemName: medal.image)
+                                            .font(.system(size: 40))
+                                    }
+                                }
+                            } //LazyVGrid
+                        } //VStack
+                        .frame(width: 330)
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(todoListGroupBorderColor.opacity(0.32),
+                                        lineWidth: 2)
+                        )
+                    } //VStack
+                } //VStack
+            } //ScrollView
             .padding()
         } //ZStack
     }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SocialDetailView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SocialDetailView.swift
@@ -21,6 +21,7 @@ struct SocialDetailView: View {
     //Fonts
     let titleFontSize: Font.TextStyle = .largeTitle
     let titleFontWeight: Font.Weight = .medium
+    let noTodoriGuideTextSize: CGFloat = 15
     
     //Colors
     let viewbackgroundColor: Color = Color(hex: 0xFFFAE1)
@@ -28,6 +29,7 @@ struct SocialDetailView: View {
     let profileBackgroundColor: Color = .white
     let cheerButtonColor: Color = Color(hex: 0xB79800)
     let hurryButtonColor: Color = Color(hex: 0xB76300)
+    let noTodoriGuideTextColor: Color = .gray
     let todoListGroupBorderColor: Color = Color(hex: 0xA58B00)
     let medalBackgroundColor: Color = .white
     
@@ -94,13 +96,26 @@ struct SocialDetailView: View {
                         
                         VStack {
                             if socialVM.isThisMonth(friend) {
+                                //이번달 투두리가 todo, wantTodo와 관계 없이 한 개라도 생성되어 있을 때
                                 let todoList: [Todo] = socialVM.getTodoList(friend)
-                                ForEach(todoList) { todo in
-                                    Text(todo.title)
-                                        .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
+                                if todoList.count == 0 {
+                                    Text("친구가 아직 투두리를 작성하지 않았어요.")
+                                        .font(.system(size: noTodoriGuideTextSize))
+                                        .foregroundStyle(noTodoriGuideTextColor)
+                                } else {
+                                    ForEach(todoList) { todo in
+                                        Text(todo.title)
+                                            .modifier(TodoCellModifier(status: todo.status, hexCode: 0xB79800))
+                                    }
                                 }
+                            } else {
+                                //이번달 투두리가 todo, wantTodo와 모두 한 개도 없을때
+                                Text("친구가 아직 투두리를 작성하지 않았어요.")
+                                    .font(.system(size: noTodoriGuideTextSize))
+                                    .foregroundStyle(noTodoriGuideTextColor)
                             }
                         } //VStack
+                        .frame(width: 330)
                         .padding()
                         .overlay(
                             RoundedRectangle(cornerRadius: 10)
@@ -119,13 +134,26 @@ struct SocialDetailView: View {
                         
                         VStack {
                             if socialVM.isThisMonth(friend) {
+                                //이번달 투두리가 todo, wantTodo와 관계 없이 한 개라도 생성되어 있을 때
                                 let wantTodoList: [WantTodo] = socialVM.getWantTodoList(friend)
-                                ForEach(wantTodoList) { wantTodo in
-                                    Text(wantTodo.title)
-                                        .modifier(TodoCellModifier(status: wantTodo.status, hexCode: 0xB76300))
+                                if wantTodoList.count == 0 {
+                                    Text("친구가 아직 투두리를 작성하지 않았어요.")
+                                        .font(.system(size: noTodoriGuideTextSize))
+                                        .foregroundStyle(noTodoriGuideTextColor)
+                                } else {
+                                    ForEach(wantTodoList) { wantTodo in
+                                        Text(wantTodo.title)
+                                            .modifier(TodoCellModifier(status: wantTodo.status, hexCode: 0xB76300))
+                                    }
                                 }
+                            } else {
+                                //이번달 투두리가 todo, wantTodo와 모두 한 개도 없을때
+                                Text("친구가 아직 투두리를 작성하지 않았어요.")
+                                    .font(.system(size: noTodoriGuideTextSize))
+                                    .foregroundStyle(noTodoriGuideTextColor)
                             }
                         } //VStack
+                        .frame(width: 330)
                         .padding()
                         .overlay(
                             RoundedRectangle(cornerRadius: 10)

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SocialView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SocialView.swift
@@ -8,8 +8,78 @@
 import SwiftUI
 
 struct SocialView: View {
+    @StateObject private var socialVM = SocialViewModel()
+    
     var body: some View {
-        Text("Social View")
+        if socialVM.isLogin {
+            SocialViewIfLogin(socialVM: socialVM)
+        } else {
+            SocialViewIfNotLogin(socialVM: socialVM)
+        }
+    }
+}
+
+struct SocialViewIfNotLogin: View {
+    @ObservedObject var socialVM: SocialViewModel
+    @State private var alertIsPresented: Bool = false
+    
+    var body: some View {
+        VStack {
+            GeometryReader { geo in
+                VStack {
+                    HStack {
+                        Text("친구")
+                            .font(.system(size: 25, weight: .heavy))
+                            .padding(.leading, 20)
+                        
+                        Spacer()
+                    }
+                    
+                    Spacer()
+                    
+                    Text("로그인 해서\n친구들의 투두리를 살펴보세요")
+                        .foregroundStyle(.gray)
+                        .multilineTextAlignment(.center)
+                        .padding(.bottom, 100)
+                    
+                    Button {
+                        alertIsPresented = true
+                    } label: {
+                        Text("카카오 로그인하기")
+                            .foregroundStyle(.white)
+                            .font(.system(.body, weight: .bold))
+                            .frame(width: 173, height: 52)
+                            .background(.orange)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                    } //Button
+                    .alert(isPresented: $alertIsPresented) {
+                        let leftButton = Alert.Button.default(Text("로그인")) {
+                            socialVM.isLogin = true
+                        }
+                        
+                        let rightButton = Alert.Button.default(Text("취소")) {
+                            socialVM.isLogin = false
+                        }
+                        
+                        return Alert(title: Text("로그인 하시겠습니까?"), 
+                                     primaryButton: rightButton,
+                                     secondaryButton: leftButton)
+                    } //alert
+                    
+                    Spacer()
+                } //VStack
+                .frame(width: geo.size.width, height: geo.size.height)
+                .background(.yellow)
+            }
+        } //VStack
+    }
+}
+
+struct SocialViewIfLogin: View {
+    @ObservedObject var socialVM: SocialViewModel
+    
+    var body: some View {
+        Text("로그인되었습니다")
     }
 }
 

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SocialView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SocialView.swift
@@ -23,13 +23,30 @@ struct SocialViewIfNotLogin: View {
     @ObservedObject var socialVM: SocialViewModel
     @State private var alertIsPresented: Bool = false
     
+    //Font
+    let titleFontSize: CGFloat = 25
+    let titleFontWeight: Font.Weight = .heavy
+    let buttonTextStyle: Font.TextStyle = .body
+    let buttonFontWeight: Font.Weight = .bold
+    
+    //Size
+    let buttonWidth: CGFloat = 173
+    let buttonHeight: CGFloat = 52
+    let buttonCornerRadius: CGFloat = 10
+    
+    //Color
+    let loginGuideTextColor: Color = .gray
+    let loginButtonTextColor: Color = .white
+    let loginButtonColor: Color = .orange
+    let viewBackground: Color = .yellow
+    
     var body: some View {
         VStack {
             GeometryReader { geo in
                 VStack {
                     HStack {
                         Text("친구")
-                            .font(.system(size: 25, weight: .heavy))
+                            .font(.system(size: titleFontSize, weight: titleFontWeight))
                             .padding(.leading, 20)
                         
                         Spacer()
@@ -38,7 +55,7 @@ struct SocialViewIfNotLogin: View {
                     Spacer()
                     
                     Text("로그인 해서\n친구들의 투두리를 살펴보세요")
-                        .foregroundStyle(.gray)
+                        .foregroundStyle(loginGuideTextColor)
                         .multilineTextAlignment(.center)
                         .padding(.bottom, 100)
                     
@@ -46,11 +63,11 @@ struct SocialViewIfNotLogin: View {
                         alertIsPresented = true
                     } label: {
                         Text("카카오 로그인하기")
-                            .foregroundStyle(.white)
-                            .font(.system(.body, weight: .bold))
-                            .frame(width: 173, height: 52)
-                            .background(.orange)
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                            .foregroundStyle(loginButtonTextColor)
+                            .font(.system(buttonTextStyle, weight: buttonFontWeight))
+                            .frame(width: buttonWidth, height: buttonHeight)
+                            .background(loginButtonColor)
+                            .clipShape(RoundedRectangle(cornerRadius: buttonCornerRadius))
                     } //Button
                     .alert(isPresented: $alertIsPresented) {
                         let leftButton = Alert.Button.default(Text("로그인")) {
@@ -69,7 +86,7 @@ struct SocialViewIfNotLogin: View {
                     Spacer()
                 } //VStack
                 .frame(width: geo.size.width, height: geo.size.height)
-                .background(.yellow)
+                .background(viewBackground)
             }
         } //VStack
     }
@@ -77,6 +94,15 @@ struct SocialViewIfNotLogin: View {
 
 struct SocialViewIfLogin: View {
     @ObservedObject var socialVM: SocialViewModel
+    
+    //Font
+    let titleFontSize: CGFloat = 25
+    let titleFontWeight: Font.Weight = .heavy
+    let buttonWeight: Font.Weight = .medium
+    
+    //Color
+    let addFriendButtonColor: Color = .black
+    let viewBackground: Color = .yellow
     
     var body: some View {
         NavigationView {
@@ -86,7 +112,7 @@ struct SocialViewIfLogin: View {
                         //뷰 제목과 친구 추가 버튼
                         HStack {
                             Text("친구")
-                                .font(.system(size: 25, weight: .heavy))
+                                .font(.system(size: titleFontSize, weight: titleFontWeight))
                                 .padding(.leading, 20)
                             
                             Spacer()
@@ -95,8 +121,8 @@ struct SocialViewIfLogin: View {
                                 //동작없음
                             } label: {
                                 Image(systemName: "plus")
-                                    .foregroundStyle(.black)
-                                    .font(.system(size: 25, weight: .medium))
+                                    .foregroundStyle(addFriendButtonColor)
+                                    .font(.system(size: titleFontSize, weight: buttonWeight))
                                     .padding(.trailing, 20)
                             } //Button
                         } //HStack
@@ -113,7 +139,7 @@ struct SocialViewIfLogin: View {
                         Spacer()
                     } //VStack
                     .frame(width: geo.size.width, height: geo.size.height)
-                    .background(.yellow)
+                    .background(viewBackground)
                 } //GeometryReader
             } //VStack
         } //NavigationView

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SocialView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SocialView.swift
@@ -164,7 +164,7 @@ struct myFriendCell: View {
     let viewBackground: Color = .yellow
     
     var body: some View {
-        NavigationLink(destination: SocialDetailView()) {
+        NavigationLink(destination: SocialDetailView(socialVM: socialVM, friend: friend)) {
             HStack {
                 //프로필이미지
                 ZStack {

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SocialView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SocialView.swift
@@ -135,6 +135,7 @@ struct myFriendCell: View {
     let profileBackgroundColor: Color = .white
     let todoTotalColor: Color = .gray
     let todoDoneColor: Color = .orange
+    let viewBackground: Color = .yellow
     
     var body: some View {
         NavigationLink(destination: SocialDetailView()) {
@@ -180,7 +181,7 @@ struct myFriendCell: View {
                 } //VStack
             } //HStack
         } //NavigationLink
-        .listRowBackground(Color.yellow)
+        .listRowBackground(viewBackground)
         .listRowSeparator(.hidden)
         
     }

--- a/PJ2T12_Again12/PJ2T12_Again12/Views/SocialView.swift
+++ b/PJ2T12_Again12/PJ2T12_Again12/Views/SocialView.swift
@@ -79,7 +79,110 @@ struct SocialViewIfLogin: View {
     @ObservedObject var socialVM: SocialViewModel
     
     var body: some View {
-        Text("로그인되었습니다")
+        NavigationView {
+            VStack {
+                GeometryReader { geo in
+                    VStack {
+                        //뷰 제목과 친구 추가 버튼
+                        HStack {
+                            Text("친구")
+                                .font(.system(size: 25, weight: .heavy))
+                                .padding(.leading, 20)
+                            
+                            Spacer()
+                            
+                            Button {
+                                //동작없음
+                            } label: {
+                                Image(systemName: "plus")
+                                    .foregroundStyle(.black)
+                                    .font(.system(size: 25, weight: .medium))
+                                    .padding(.trailing, 20)
+                            } //Button
+                        } //HStack
+                        
+                        //친구 리스트
+                        List {
+                            ForEach(socialVM.myFriendsList) { friend in
+                                myFriendCell(socialVM: socialVM, friend: friend)
+                            }
+                        } //List
+                        .listStyle(.plain)
+                        .scrollContentBackground(.hidden)
+                        
+                        Spacer()
+                    } //VStack
+                    .frame(width: geo.size.width, height: geo.size.height)
+                    .background(.yellow)
+                } //GeometryReader
+            } //VStack
+        } //NavigationView
+    }
+}
+
+struct myFriendCell: View {
+    @ObservedObject var socialVM: SocialViewModel
+    @State var friend: User
+    
+    //Sizes
+    let circleSize: CGFloat = 64
+    let profileIconSize: CGFloat = 25
+    let verticalStackWidth: CGFloat = 22
+    let verticalStackHeight: CGFloat = 15
+    
+    //Colors
+    let profileBorderColor: Color = .black
+    let profileBackgroundColor: Color = .white
+    let todoTotalColor: Color = .gray
+    let todoDoneColor: Color = .orange
+    
+    var body: some View {
+        NavigationLink(destination: SocialDetailView()) {
+            HStack {
+                //프로필이미지
+                ZStack {
+                    Circle()
+                        .stroke(profileBorderColor, lineWidth: 1.0)
+                        .frame(width: circleSize, height: circleSize)
+                        .background(profileBackgroundColor)
+                        .clipShape(Circle())
+                    
+                    Image(systemName: friend.profileImage ?? "person")
+                        .font(.system(size: profileIconSize))
+                } //ZStack
+                .padding(.trailing, 10)
+                
+                //친구이름 + 가로그래프 + 투두 개수
+                VStack(alignment: .leading) {
+                    Text(friend.name ?? "Error")
+                    //가로그래프 + 투두 개수
+                    HStack {
+                        let todoTotal = socialVM.countTotal(friend)
+                        let todoDone = socialVM.countDone(friend)
+                        
+                        //가로그래프
+                        HStack {
+                            ZStack(alignment: .leading) {
+                                Rectangle()
+                                    .frame(width: verticalStackWidth * CGFloat(todoTotal), height: verticalStackHeight)
+                                    .foregroundStyle(todoTotalColor)
+                                Rectangle()
+                                    .frame(width: verticalStackWidth * CGFloat(todoDone), height: verticalStackHeight)
+                                    .foregroundStyle(todoDoneColor)
+                            }//ZStack
+                            
+                            Spacer()
+                        } //HStack
+                        .frame(width: verticalStackWidth * 6)
+                        
+                        Text("\(todoDone) / \(todoTotal)")
+                    }
+                } //VStack
+            } //HStack
+        } //NavigationLink
+        .listRowBackground(Color.yellow)
+        .listRowSeparator(.hidden)
+        
     }
 }
 


### PR DESCRIPTION
## 이슈번호
🔐close #45 #46 #47 #48 #49 #50 #51 

## 작업사항
- 로그인 하기 전과 후의 전체적인 UI를 생성했습니다.
- 로그인 하기 전 화면에서 카카오 로그인하기 버튼을 누르면 Alert창이 뜹니다.
- Alert창에서 로그인 버튼을 누르면 로그인 후 화면이 보인다.
- SocialViewModel에서 친구가 등록한 투두리의 가장 최신 데이터가 이번달의 데이터가 맞는지 체크 한 다음 화면에 리스트와 리스트 개수를 가지고 올 수 있도록 했습니다.
- 로그인 한 후 보여지는 친구 리스트를 선택하면 Detail View로 넘어간다.
- 친구 DetailView에는 해당 친구의 프로필사진, 닉네임과 Todo, WantTodo, Badge가 보여진다.
- 친구 DetailView에는 친구에게 응원과 재촉을 보낼 수 있는 버튼이 있다.

## 향후 작업예정
- Color 변경
- 로그인 API 연결시 해당 기능으로 변경
- User Model 업데이트
- 친구 DeatilView에서 Medal 데이터를 true인것만 가지고 올지 결정해야함

## 스크린샷
| 작업 전 | 작업 후 |
| :-: | :-: | 
| |<img width="256" alt="스크린샷 2023-12-13 오전 10 56 59" src="https://github.com/APP-iOS3rd/PJ2T12_Again12/assets/106911494/d3b5fe3b-fe5e-4cd0-bd7b-ee497ca0fde7">|
| |<img width="256" alt="스크린샷 2023-12-13 오전 10 57 09" src="https://github.com/APP-iOS3rd/PJ2T12_Again12/assets/106911494/7f7a1ee0-2034-46ae-88c1-4a303551232d">|
| |<img width="256" alt="스크린샷 2023-12-13 오전 10 57 14" src="https://github.com/APP-iOS3rd/PJ2T12_Again12/assets/106911494/15b443eb-3bf4-419e-b7c8-3f1c691dbc5f">|
| |<img width="256" alt="스크린샷 2023-12-13 오전 10 57 18" src="https://github.com/APP-iOS3rd/PJ2T12_Again12/assets/106911494/1f414e72-98fe-402d-b23f-18b321d502b9">|